### PR TITLE
Remove stderr debug prints

### DIFF
--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -346,10 +346,6 @@ impl XsdValidator {
             members.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
             members.dedup();
         }
-        eprintln!(
-            "DEBUG: substitution_groups: {:?}",
-            validator.substitution_groups
-        );
 
         // Resolution pass: propagate list type info from base types to derived types.
         // Types that restrict a list type inherit is_list and item_type.

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -32,13 +32,6 @@ impl XsdValidator {
             }
 
             let selected = idc_select_nodes(doc, context_node, &constraint.selector);
-            eprintln!(
-                "DEBUG: identity constraint '{}' ({:?}): selector='{}' selected {} nodes",
-                constraint.name,
-                constraint.kind,
-                constraint.selector,
-                selected.len()
-            );
 
             let mut tuples: Vec<Vec<String>> = Vec::new();
 
@@ -163,23 +156,11 @@ impl XsdValidator {
 
             let referred_tuples = key_tables.get(refer_name);
             if referred_tuples.is_none() {
-                eprintln!(
-                    "DEBUG: keyref '{}' refers to '{}' which was not found in this scope",
-                    constraint.name, refer_name
-                );
                 continue;
             }
             let referred_tuples = referred_tuples.unwrap();
 
             let selected = idc_select_nodes(doc, context_node, &constraint.selector);
-            eprintln!(
-                "DEBUG: keyref '{}': selector='{}' selected {} nodes, referred key '{}' has {} tuples",
-                constraint.name,
-                constraint.selector,
-                selected.len(),
-                refer_name,
-                referred_tuples.len()
-            );
 
             for &sel_node in &selected {
                 let mut field_values: Vec<Option<String>> = Vec::new();

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -203,11 +203,6 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                     }
                 }
 
-                eprintln!(
-                    "DEBUG: parsed identity constraint: kind={:?} name={} selector={} fields={:?} refer={:?}",
-                    kind, name, selector, fields, refer
-                );
-
                 constraints.push(IdentityConstraint {
                     name,
                     kind,

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -907,20 +907,12 @@ impl XsdValidator {
 
             // Validate attribute values against their declared types
             for attr_decl in &effective_attrs {
-                eprintln!(
-                    "DEBUG: effective_attr name={} type_ref={:?}",
-                    attr_decl.name, attr_decl.type_ref
-                );
                 if let Some(attr) = elem
                     .attributes
                     .iter()
                     .find(|a| a.name.local_name == attr_decl.name)
                 {
                     let value = &attr.value;
-                    eprintln!(
-                        "DEBUG: validating attr {}={} against {:?}",
-                        attr_decl.name, value, attr_decl.type_ref
-                    );
                     self.validate_attribute_value(value, &attr_decl.type_ref, doc, node, errors);
                 }
             }
@@ -2025,16 +2017,7 @@ impl XsdValidator {
             TypeRef::Named(ns, name) => {
                 // Try to resolve the named type
                 let key = (ns.clone(), name.clone());
-                eprintln!(
-                    "DEBUG: validate_attribute_value Named key={:?} found={}",
-                    key,
-                    self.types.contains_key(&key)
-                );
                 if let Some(TypeDef::Simple(st)) = self.types.get(&key) {
-                    eprintln!(
-                        "DEBUG: SimpleTypeDef base={:?} facets={:?}",
-                        st.base, st.facets
-                    );
                     if st.is_list {
                         let items: Vec<&str> = value.split_whitespace().collect();
                         if let Some(ref item_bt) = st.item_type {


### PR DESCRIPTION
Hi!

Would it be possible to remove the debug prints to stderr in the latest crate version?
Or perhaps, make them optional?

They can become very verbose depending on the application.