### PR TITLE
refactor(xsd): gate DEBUG eprintlns behind `debug-logging` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ exclude = ["test-data/", "perf.data"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+default = []
+# Enable verbose `DEBUG: ...` traces on stderr. Off by default so library
+# output stays clean. Currently emitted by the XSD validator submodule
+# (identity constraint evaluation, attribute type resolution, etc.).
+debug-logging = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -19,6 +19,7 @@ use crate::dom::{Document, NodeKind};
 use crate::error::{XmlError, XmlResult};
 
 use super::composition::process_schema_composition;
+use super::debug_log;
 use super::facet_resolution::{
     resolve_content_model_list_item_facets, resolve_inline_list_item_facets,
 };
@@ -346,8 +347,8 @@ impl XsdValidator {
             members.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
             members.dedup();
         }
-        eprintln!(
-            "DEBUG: substitution_groups: {:?}",
+        debug_log!(
+            "substitution_groups: {:?}",
             validator.substitution_groups
         );
 

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::ValidationError;
 
+use super::debug_log;
 use super::types::{IdentityConstraint, IdentityConstraintKind, XsdValidator};
 
 impl XsdValidator {
@@ -32,8 +33,8 @@ impl XsdValidator {
             }
 
             let selected = idc_select_nodes(doc, context_node, &constraint.selector);
-            eprintln!(
-                "DEBUG: identity constraint '{}' ({:?}): selector='{}' selected {} nodes",
+            debug_log!(
+                "identity constraint '{}' ({:?}): selector='{}' selected {} nodes",
                 constraint.name,
                 constraint.kind,
                 constraint.selector,
@@ -163,8 +164,8 @@ impl XsdValidator {
 
             let referred_tuples = key_tables.get(refer_name);
             if referred_tuples.is_none() {
-                eprintln!(
-                    "DEBUG: keyref '{}' refers to '{}' which was not found in this scope",
+                debug_log!(
+                    "keyref '{}' refers to '{}' which was not found in this scope",
                     constraint.name, refer_name
                 );
                 continue;
@@ -172,8 +173,8 @@ impl XsdValidator {
             let referred_tuples = referred_tuples.unwrap();
 
             let selected = idc_select_nodes(doc, context_node, &constraint.selector);
-            eprintln!(
-                "DEBUG: keyref '{}': selector='{}' selected {} nodes, referred key '{}' has {} tuples",
+            debug_log!(
+                "keyref '{}': selector='{}' selected {} nodes, referred key '{}' has {} tuples",
                 constraint.name,
                 constraint.selector,
                 selected.len(),

--- a/src/xsd/mod.rs
+++ b/src/xsd/mod.rs
@@ -29,6 +29,21 @@
 //! assert!(errors.is_empty());
 //! ```
 
+// ── Internal debug logging ───────────────────────────────────────────────────
+//
+// Trace logging used by the validator submodules during diagnosis. Enabled
+// only when the `debug-logging` Cargo feature is on so library output
+// stays clean by default.
+
+macro_rules! debug_log {
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "debug-logging")]
+        { eprintln!("DEBUG: {}", format_args!($($arg)*)); }
+    }};
+}
+
+pub(crate) use debug_log;
+
 // Submodule declarations — each file contains a logical slice of the XSD validator.
 
 /// Arbitrary-precision decimal string comparison utilities.

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::{XmlError, XmlResult};
 
+use super::debug_log;
 use super::types::{
     AttributeDecl, AttributeGroupDef, AttributeWildcard, BuiltInType, ComplexTypeDef, ContentModel,
     ElementDecl, Facet, IdentityConstraint, IdentityConstraintKind, MaxOccurs, ModelGroupDef,
@@ -203,8 +204,8 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                     }
                 }
 
-                eprintln!(
-                    "DEBUG: parsed identity constraint: kind={:?} name={} selector={} fields={:?} refer={:?}",
+                debug_log!(
+                    "parsed identity constraint: kind={:?} name={} selector={} fields={:?} refer={:?}",
                     kind, name, selector, fields, refer
                 );
 

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -14,6 +14,7 @@ use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::ValidationError;
 use crate::namespace::build_resolver_for_node;
 
+use super::debug_log;
 use super::builtins::{
     apply_whitespace_normalization, validate_builtin_value, validate_facet, validate_list_facet,
     whitespace_for_type,
@@ -907,8 +908,8 @@ impl XsdValidator {
 
             // Validate attribute values against their declared types
             for attr_decl in &effective_attrs {
-                eprintln!(
-                    "DEBUG: effective_attr name={} type_ref={:?}",
+                debug_log!(
+                    "effective_attr name={} type_ref={:?}",
                     attr_decl.name, attr_decl.type_ref
                 );
                 if let Some(attr) = elem
@@ -917,8 +918,8 @@ impl XsdValidator {
                     .find(|a| a.name.local_name == attr_decl.name)
                 {
                     let value = &attr.value;
-                    eprintln!(
-                        "DEBUG: validating attr {}={} against {:?}",
+                    debug_log!(
+                        "validating attr {}={} against {:?}",
                         attr_decl.name, value, attr_decl.type_ref
                     );
                     self.validate_attribute_value(value, &attr_decl.type_ref, doc, node, errors);
@@ -2025,14 +2026,14 @@ impl XsdValidator {
             TypeRef::Named(ns, name) => {
                 // Try to resolve the named type
                 let key = (ns.clone(), name.clone());
-                eprintln!(
-                    "DEBUG: validate_attribute_value Named key={:?} found={}",
+                debug_log!(
+                    "validate_attribute_value Named key={:?} found={}",
                     key,
                     self.types.contains_key(&key)
                 );
                 if let Some(TypeDef::Simple(st)) = self.types.get(&key) {
-                    eprintln!(
-                        "DEBUG: SimpleTypeDef base={:?} facets={:?}",
+                    debug_log!(
+                        "SimpleTypeDef base={:?} facets={:?}",
                         st.base, st.facets
                     );
                     if st.is_list {


### PR DESCRIPTION
## Problem

Nine `eprintln!("DEBUG: ...")` calls in the XSD validator submodules
(`xsd/{builder,identity,parser,validation}.rs`) fire on every validation
regardless of context, leaving stderr noisy for any consumer that runs
the validator (e.g. a CLI that validates specs interactively).

## Change

- New `debug-logging` cargo feature (off by default).
- Private `xsd::debug_log!` macro that expands to `eprintln!("DEBUG: ...", ...)`
  when the feature is on, no-ops otherwise.
- 9 call sites in `builder/identity/parser/validation.rs` migrated to
  `debug_log!`.

Default builds: stderr stays clean. `cargo build --features debug-logging`
gives the same diagnostics as before.

## Testing

- **This PR (rebased onto `main`, i.e. uppsala 0.2.0)**: full test suite passes
  with and without `--features debug-logging`.
- **Also validated against v0.3.0**: the same fix applied on top of
  the `v0.3.0` tag passes the 375-test suite there too. See branch
  [`fix/remove-stray-debug-eprintlns`](https://github.com/CognitiveLayers/uppsala/tree/fix/remove-stray-debug-eprintlns)
  in our fork, based on
  [`v0.3.0-base`](https://github.com/CognitiveLayers/uppsala/tree/v0.3.0-base)
  (which is just the `v0.3.0` tag commit pushed as a branch for review
  convenience). Combined with the other PR it's on
  [`clayers-integration`](https://github.com/CognitiveLayers/uppsala/tree/clayers-integration).