### PR TITLE
fix(xsd): resolve element-ref prefixes against in-scope namespaces

### DIFF
--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::{XmlError, XmlResult};
+use crate::namespace::build_resolver_for_node;
 
 use super::types::{
     AttributeDecl, AttributeGroupDef, AttributeWildcard, BuiltInType, ComplexTypeDef, ContentModel,
@@ -970,12 +971,26 @@ fn parse_particles(
                     // Check if this is an element reference (<element ref="..."/>)
                     if let Some(ref_name) = child_elem.get_attribute("ref") {
                         let local_name = strip_prefix(ref_name);
-                        // Resolve namespace from prefix if present
-                        let ref_ns = if ref_name.contains(':') {
-                            // Prefixed ref — use schema target namespace
-                            schema_target_ns.clone()
+                        // Resolve namespace from prefix if present.
+                        //
+                        // For prefixed refs like "trm:ref", the prefix is
+                        // resolved via the in-scope namespace declarations on
+                        // the `<xs:element>` node — not the schema's own
+                        // targetNamespace. A prefix typically points to a
+                        // foreign namespace introduced via xs:import; using
+                        // the schema's target instead would silently rebind
+                        // the reference to the wrong namespace and cause
+                        // matching failures at validation time.
+                        //
+                        // For unprefixed refs the QName resolves to the
+                        // schema's target namespace per the XSD spec
+                        // (regardless of any default xmlns in scope).
+                        let ref_ns = if let Some(colon_idx) = ref_name.find(':') {
+                            let prefix = &ref_name[..colon_idx];
+                            build_resolver_for_node(doc, child)
+                                .resolve(prefix)
+                                .map(|uri| uri.to_string())
                         } else {
-                            // Unprefixed ref — use schema target namespace for qualified schemas
                             schema_target_ns.clone()
                         };
                         particles.push(Particle {

--- a/tests/xsd_composition.rs
+++ b/tests/xsd_composition.rs
@@ -1,0 +1,139 @@
+//! Regression tests for XSD schema composition (`xs:import`, `xs:include`,
+//! `xs:redefine`) interacting with content models.
+//!
+//! Each test that needs sibling schema files writes them to a unique
+//! tempdir and passes the schema path to `from_schema_with_base_path` so
+//! `schemaLocation` resolution works. No external test fixture files.
+
+use std::fs;
+use std::path::PathBuf;
+
+use uppsala::{parse, XsdValidator};
+
+fn mkdir_unique(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "uppsala-test-{}-{}-{}",
+        label,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+fn validate(schema: &str, schema_path: &std::path::Path, instance: &str) -> Vec<String> {
+    let schema_doc = parse(schema).expect("parse schema");
+    let validator = XsdValidator::from_schema_with_base_path(&schema_doc, Some(schema_path))
+        .expect("build validator");
+    let doc = parse(instance).expect("parse instance");
+    validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| format!("{}", e))
+        .collect()
+}
+
+/// Control case: same-namespace `xs:element ref="..."` inside an unbounded
+/// choice in mixed content. This works correctly today and is included so
+/// the cross-namespace regression below can be compared against a known-good
+/// baseline.
+#[test]
+fn same_namespace_ref_in_unbounded_choice_mixed_content() {
+    let dir = mkdir_unique("same-ns-choice");
+    let schema = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="urn:test:m"
+           targetNamespace="urn:test:m"
+           elementFormDefault="qualified">
+  <xs:element name="ref">
+    <xs:complexType><xs:attribute name="term" type="xs:string"/></xs:complexType>
+  </xs:element>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="m:ref"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    let schema_path = dir.join("schema.xsd");
+    fs::write(&schema_path, schema).unwrap();
+
+    let instance = r#"<m:p xmlns:m="urn:test:m">
+Text <m:ref term="x"/> and <m:b>bold</m:b> and <m:ref term="y"/> more.
+</m:p>"#;
+
+    let errors = validate(schema, &schema_path, instance);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(
+        errors.is_empty(),
+        "same-namespace ref in unbounded choice should validate, got: {:?}",
+        errors
+    );
+}
+
+/// Regression: when an `xs:element ref="foreign:name"` (resolved across an
+/// `xs:import` boundary) appears inside an unbounded choice in mixed content,
+/// validation incorrectly reports `Unexpected element ... after choice` for
+/// the second and subsequent occurrences. This is the "cross-namespace ref
+/// in unbounded choice" bug.
+///
+/// Schema layout:
+///   inner.xsd — defines a global element `i:ref` in namespace `urn:test:inner`
+///   outer.xsd — imports inner, declares `o:p` whose content model is
+///               mixed + unbounded choice over `i:ref` and a local `b`.
+///
+/// Instance: `<o:p>` containing two `<i:ref/>` interleaved with text and a
+/// `<o:b>`. By spec this is valid (choice is unbounded; mixed allows text).
+#[test]
+fn cross_namespace_ref_in_unbounded_choice_mixed_content() {
+    let dir = mkdir_unique("cross-ns-choice");
+
+    let inner = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:i="urn:test:inner"
+           targetNamespace="urn:test:inner"
+           elementFormDefault="qualified">
+  <xs:element name="ref">
+    <xs:complexType><xs:attribute name="term" type="xs:string"/></xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    fs::write(dir.join("inner.xsd"), inner).unwrap();
+
+    let outer = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:i="urn:test:inner"
+           xmlns:o="urn:test:outer"
+           targetNamespace="urn:test:outer"
+           elementFormDefault="qualified">
+  <xs:import namespace="urn:test:inner" schemaLocation="inner.xsd"/>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="i:ref"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    let outer_path = dir.join("outer.xsd");
+    fs::write(&outer_path, outer).unwrap();
+
+    let instance = r#"<o:p xmlns:o="urn:test:outer" xmlns:i="urn:test:inner">
+Text with <i:ref term="x"/> and <o:b>bold</o:b> and <i:ref term="y"/>.
+</o:p>"#;
+
+    let errors = validate(outer, &outer_path, instance);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(
+        errors.is_empty(),
+        "cross-namespace ref in unbounded choice should validate, got: {:?}",
+        errors
+    );
+}


### PR DESCRIPTION
## Problem

When parsing `<xs:element ref="prefix:name"/>` inside a content model
compositor, the parser strips the prefix and uses the schema's own
`targetNamespace` as the referenced element's namespace — regardless of
what the prefix is actually bound to. For schemas that import foreign
elements via `xs:import`, this silently rebinds the reference to the
wrong namespace and causes matching failures at validation time.

Concretely, a schema like:

```xml
<xs:schema targetNamespace="urn:a" xmlns:b="urn:b">
  <xs:import namespace="urn:b" schemaLocation="b.xsd"/>
  <xs:element name="p">
    <xs:complexType mixed="true">
      <xs:choice minOccurs="0" maxOccurs="unbounded">
        <xs:element ref="b:ref"/>
        <xs:element name="bold" type="xs:string"/>
      </xs:choice>
    </xs:complexType>
  </xs:element>
</xs:schema>
```

…with an instance `<a:p>Text <b:ref/> and <a:bold>hi</a:bold> and <b:ref/>.</a:p>`
fails validation with `"Unexpected element 'ref' after choice"` on the
second occurrence, because the particle was registered under `urn:a`
(wrong namespace) and doesn't match instances in `urn:b`.

See `src/xsd/parser.rs` around line 973 for the original logic: the
`if ref_name.contains(':')` branch and the `else` branch both use
`schema_target_ns.clone()`, making the prefix a no-op.

## Fix

Resolve the prefix via `build_resolver_for_node(doc, child)` against
the in-scope namespace declarations on the `<xs:element>` node — this
is how XSD QNames are intended to bind. Unprefixed refs continue to
use the schema's target namespace per the XSD spec.

```rust
let ref_ns = if let Some(colon_idx) = ref_name.find(':') {
    let prefix = &ref_name[..colon_idx];
    build_resolver_for_node(doc, child)
        .resolve(prefix)
        .map(|uri| uri.to_string())
} else {
    schema_target_ns.clone()
};
```

## Testing

- New integration test `tests/xsd_composition.rs` with:
  - `cross_namespace_ref_in_unbounded_choice_mixed_content` — the
    regression case (writes two sibling schemas to a tempdir, uses
    `xs:import`, validates a mixed-content instance).
  - `same_namespace_ref_in_unbounded_choice_mixed_content` — the
    control, demonstrating the same-namespace case worked before.
- Full test suite passes on this branch (rebased onto `main`, uppsala 0.2.0).
- Also validated on top of the `v0.3.0` tag: 375 + 2 tests pass.
  See branch
  [`fix/cross-ns-ref-in-unbounded-choice-mixed-content`](https://github.com/CognitiveLayers/uppsala/tree/fix/cross-ns-ref-in-unbounded-choice-mixed-content)
  in our fork, based on
  [`v0.3.0-base`](https://github.com/CognitiveLayers/uppsala/tree/v0.3.0-base).
  Combined with the other PR it's on
  [`clayers-integration`](https://github.com/CognitiveLayers/uppsala/tree/clayers-integration).