### PR TITLE
security: harden parser, serializer, XPath 1.0, and XSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Unit and hand-crafted tests
         run: cargo test --lib --test xml_conformance --test namespace_conformance --test xpath_conformance --test xsd_conformance --test serialization_conformance --test range_conformance
 
+      # Security regression coverage. The fail-closed assertions run by
+      # default; `#[ignore]`-marked process-fatal reproducers in
+      # security_audit are skipped here and run manually with `-- --ignored`.
+      - name: Security regression tests
+        run: cargo test --test security_regressions --test hardening_regressions --test security_audit
+
       # W3C conformance suites — the full XML test suite (~1 208 tests) and
       # the three XSD test suites (NIST ~19 217, MS ~1 213, Sun ~199). All
       # fully deterministic; split into named steps so the CI log shows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout uppsala
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout uppsala
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uppsala"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A pure Rust XML parser, DOM, namespace, XPath, and XSD validation library"
 license = "BSD-2-Clause"

--- a/audit/pocs/billion_laughs.xml
+++ b/audit/pocs/billion_laughs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<lolz>&lol9;</lolz>

--- a/audit/pocs/deep_nesting.xml.md
+++ b/audit/pocs/deep_nesting.xml.md
@@ -1,0 +1,5 @@
+Deep-nesting PoC is generated at test-time rather than stored as a
+multi-megabyte file. See tests/security_audit.rs::deep_nesting_parser
+and ::deep_nesting_xpath — each builds an input of ~100k levels and
+proves the parser recurses without a depth cap (stack overflow aborts
+the test binary on Linux with the default 8 MiB stack).

--- a/audit/pocs/quadratic_blowup.xml
+++ b/audit/pocs/quadratic_blowup.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- Quadratic blowup: one large entity referenced many times.
+     Entity A is 10,000 characters; referenced 10,000 times =>
+     final expansion ~100 MB, built up in memory via repeated cache clones. -->
+<!DOCTYPE doc [
+  <!ENTITY a "AAAAAAAAAAAAAAAAAAAA">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+]>
+<doc>&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;</doc>

--- a/audit/pocs/redos_pattern.xsd
+++ b/audit/pocs/redos_pattern.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Polynomial ReDoS via nested repetition (a*)*b against aaaa...X.
+     Matcher returns O(n^3) reachable positions; completes eventually for
+     small inputs but stalls for attacker-sized ones. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="s" type="vulnerableType"/>
+  <xs:simpleType name="vulnerableType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(a*)*b"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/audit/pocs/regex_huge_brace.xsd
+++ b/audit/pocs/regex_huge_brace.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Schema-side DoS: {n,m} with a huge upper bound. Compiler accepts
+     the pattern; matcher will loop up to m iterations (saturation
+     eventually kicks in, but CPU time is proportional to min(m, n)). -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="s" type="vulnerableType"/>
+  <xs:simpleType name="vulnerableType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="a{0,4000000000}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/audit/pocs/roundtrip_comment_smuggle.txt
+++ b/audit/pocs/roundtrip_comment_smuggle.txt
@@ -1,0 +1,6 @@
+Round-trip injection via programmatically constructed comment.
+A DOM comment node whose text contains `-->` is serialized verbatim by
+`Document::to_xml()` / `XmlWriter::comment()`, producing output where the
+comment terminates early and subsequent chars become markup.
+
+Reproducer in tests/security_audit.rs::roundtrip_comment_smuggle.

--- a/audit/pocs/unknown_prop_bypass.xsd
+++ b/audit/pocs/unknown_prop_bypass.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- Pattern facet with unknown \p{...} category. The regex engine
+     silently treats unknown categories as "match nothing", and \P{unknown}
+     as "match everything" - so restrictions using unknown property names
+     are ineffectual. Attacker-controlled schemas can bypass validation. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="s" type="hexOnly"/>
+  <xs:simpleType name="hexOnly">
+    <xs:restriction base="xs:string">
+      <!-- Intended: only hex digits. Actual: \P{unknowncategory} matches every char. -->
+      <xs:pattern value="\P{unknowncategory}+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/audit/pocs/utf16_odd_byte.bin
+++ b/audit/pocs/utf16_odd_byte.bin
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-16LE"?><r/>X

--- a/audit/pocs/xsd_circular_include_a.xsd
+++ b/audit/pocs/xsd_circular_include_a.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="xsd_circular_include_b.xsd"/>
+  <xs:element name="a" type="xs:string"/>
+</xs:schema>

--- a/audit/pocs/xsd_circular_include_b.xsd
+++ b/audit/pocs/xsd_circular_include_b.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="xsd_circular_include_a.xsd"/>
+  <xs:element name="b" type="xs:string"/>
+</xs:schema>

--- a/audit/pocs/xxe_file_read.xsd
+++ b/audit/pocs/xxe_file_read.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- When a caller invokes XsdValidator::from_schema_with_base_path(...),
+     a schemaLocation pointing at an absolute path (or traversing via ..)
+     is read via std::fs::read_to_string with no sandboxing.
+
+     Target path is substituted at test time by tests/security_audit.rs;
+     this file is a template. The real schemaLocation is patched before
+     the validator builds the schema. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="__TARGET_PATH__"/>
+  <xs:element name="x" type="xs:string"/>
+</xs:schema>

--- a/docs/adr/0007-security-hardening-0.5.0.md
+++ b/docs/adr/0007-security-hardening-0.5.0.md
@@ -1,0 +1,145 @@
+# Security Hardening Defaults for 0.5.0
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-06-26
+
+## Context
+
+Uppsala is commonly used on XML that may cross trust boundaries before being
+serialized, queried, or validated. A security review found several places where
+the library preserved or accepted ambiguous XML state:
+
+- DTD declarations were preserved by default during serialization, which could
+  hand an XXE-capable `DOCTYPE` to downstream XML processors.
+- Programmatic element and attribute names could be serialized without XML name
+  validation.
+- Namespace-sensitive parser, XPath, and XSD paths sometimes compared only local
+  names or fell back to no-namespace declarations.
+- XSD named type references could fail open when resolution failed.
+- XPath axis traversal lacked allocation limits.
+- DOM tree mutation accepted invalid or cyclic `NodeId` relationships.
+
+A follow-up **differential security review** of the same release was then run and
+reproduced several additional issues with compiled proof-of-concept programs.
+They cluster into two root causes:
+
+1. **Two existing limits were charged in the wrong place, so they were
+   bypassable.** The XSD-regex match-step budget counted one tick per
+   `match_node` entry while a single entry could do O(N) allocation work; the
+   XPath 1.0 node-visit budget charged node-set *construction* but not the
+   O(n·m) node-set *comparison*. Both let an attacker do super-linear work while
+   staying under the configured cap.
+
+2. **A handful of residual panics / injection / output-correctness gaps**
+   survived the first pass: an unsanitized processing-instruction target, fixed
+   byte-index slicing in three datetime validators, a `substring` integer
+   overflow, a duplicate-namespace-declaration serialization bug, and a
+   deep-linear-entity-chain stack overflow not covered by the byte budget.
+
+A recurring lesson: **a resource limit only works if it is charged where the
+cost is actually incurred.**
+
+## Decision
+
+Version 0.5.0 makes the secure behavior the default:
+
+- Parsed `Document::doctype` is still preserved for inspection, but serializers
+  omit it by default. Trusted callers can opt in with
+  `XmlWriteOptions::with_doctype(true)`.
+- DOM and `XmlWriter` serialization replace invalid structural QNames with `_`.
+- Namespace-expanded attributes are checked for duplicates after namespace
+  resolution.
+- XPath 1.0 name tests are namespace-aware and require explicit prefix bindings.
+- XPath 1.0 axis/predicate traversal is bounded by configurable defaults.
+- XSD root lookup, type resolution, identity constraints, wildcard merging, and
+  complex type derivation now fail closed on namespace mismatch, unresolved
+  types, malformed temporal values, and derivation cycles.
+- Public DOM mutation APIs no-op on invalid handles or cycle-forming moves.
+
+### Differential-review second pass
+
+The follow-up findings are fixed preferring corrections that *preserve behaviour
+for legitimate input* (lazy allocation, charging the real cost) over blanket
+rejection, and a dedicated regression suite (`tests/hardening_regressions.rs`)
+pins each one. Finding labels below match the test function names.
+
+One new limit was added, following ADR 0004's "default constant + per-type
+builder" pattern:
+
+| Constant | Value | Applies to | Builder |
+|----------|-------|------------|---------|
+| `parser::DEFAULT_MAX_ENTITY_DEPTH` | 256 | Entity replacement-text expansion nesting depth | (internal; bounded alongside the byte budget) |
+
+Per-finding decisions:
+
+- **F4 — XSD regex quadratic allocation.** `match_repetition` allocated an
+  O(N) `seen` bitmap on entry, before knowing whether the repetition could
+  advance. An outer repetition calling it O(N) times made that O(N²) — work the
+  per-entry step budget never charged. The bitmap is now allocated **lazily**,
+  only on the first productive greedy iteration, so the common
+  `a*b*`-over-`aaaa…` shape stays linear and still matches correctly.
+
+- **F5 — XPath 1.0 node-set comparison uncharged.** `=`/`!=` over node-sets is
+  an O(n·m) string-value scan. It is now charged against the existing node-visit
+  budget (`charge_comparison`, proportional to the operand cardinalities), so a
+  comparison built from cheap child-axis operands can no longer run for minutes
+  under the cap.
+
+- **F6 — Processing-instruction target injection.** A PI target containing `?>`
+  plus markup broke out of PI position. `sanitize_pi_target` now validates the
+  target as an XML NCName (collapsing invalid targets to `_`) in addition to
+  renaming the reserved `xml` target. Both the `XmlWriter` and DOM serializer
+  share the helper.
+
+- **F7 — Deep linear entity chain.** A non-cyclic chain `e0 → e1 → … → eN` with
+  a tiny leaf expands to ~1 byte (so the byte budget never trips) yet recurses
+  N frames deep. Expansion depth (`seen.len()`) is now capped at
+  `DEFAULT_MAX_ENTITY_DEPTH`, failing closed with a normal error.
+
+- **F8 — datetime multibyte panic.** `is_valid_gmonth` / `is_valid_gday` /
+  `is_valid_gmonthday` sliced fixed byte ranges after only length checks,
+  panicking when a multibyte character straddled a boundary. They now reject
+  non-ASCII input up front (these lexical forms are entirely ASCII).
+
+- **F10 — duplicate namespace declarations.** Two distinct invalid prefixes both
+  sanitize to `_`, which emitted duplicate `xmlns:_` attributes (not
+  well-formed). The serializer now disambiguates colliding prefixes (preserving
+  both URIs) and skips an impossible duplicate default-namespace declaration.
+
+- **F11 — `substring()` overflow.** `start + len` overflowed `usize` for
+  `inf`/huge length arguments. It now uses `saturating_add` and clamps, so the
+  result is the (clamped) substring with no panic in either build profile.
+
+- **F12 — unknown Unicode property/block names.** The 0.5.0 change to reject
+  unknown property names at compile time (so `\P{IsTypo}` cannot match every
+  character) was reviewed for over-restriction. On audit the block table already
+  matches the XSD 1.0 Part 2 Appendix-F **closed** list, so the fail-closed
+  rejection is spec-correct, not a regression. This was resolved by
+  **documentation only**: `is_known_property_name` and `match_unicode_block` now
+  state that the recognized set is the XSD-defined closed list, so a future
+  reader does not "loosen" it back into the bypass. No behavioural change.
+
+## Consequences
+
+This is a behavior change for callers that depended on automatic DTD
+round-tripping, local-name-only XPath/XSD matching, or permissive invalid
+programmatic names. These changes are included in the 0.5.0 release because
+they close validation and serialization bypasses in security-sensitive
+embeddings. Callers that intentionally round-trip trusted DTDs must opt in
+explicitly at serialization time.
+
+For the differential-review second pass:
+
+- F4 and F5 change pathological cases from "slow success" to "fast, clean
+  error", and F6/F8/F11 change pathological cases from "panic"/"injection" to a
+  clean error or sanitized output. Legitimate input is unaffected — each fix
+  ships with a "valid input still works" regression assertion in
+  `tests/hardening_regressions.rs`.
+- All W3C conformance suites remain at their prior pass rates (XML 100%, XSTS
+  NIST 100%, MS 100%, Sun 100%), the library still builds with zero warnings,
+  and `tests/hardening_regressions.rs` guards every finding against recurrence.

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -665,9 +665,14 @@ impl<'a> Document<'a> {
     pub fn children(&self, id: NodeId) -> Vec<NodeId> {
         let mut result = Vec::new();
         let mut current = self.nodes.get(id.0).and_then(|n| n.first_child);
+        let mut steps = 0usize;
         while let Some(child_id) = current {
+            if child_id.0 >= self.nodes.len() || steps >= self.nodes.len() {
+                break;
+            }
             result.push(child_id);
             current = self.nodes.get(child_id.0).and_then(|n| n.next_sibling);
+            steps += 1;
         }
         result
     }
@@ -925,6 +930,9 @@ impl<'a> Document<'a> {
 
     /// Append a child node to a parent. Detaches the child from any previous parent.
     pub fn append_child(&mut self, parent: NodeId, child: NodeId) {
+        if !self.can_reparent(parent, child) {
+            return;
+        }
         // Detach from old parent first
         self.detach(child);
         self.append_child_unchecked(parent, child);
@@ -934,6 +942,9 @@ impl<'a> Document<'a> {
     /// The child must have no parent, no siblings. Used during parsing for speed.
     #[inline]
     pub(crate) fn append_child_unchecked(&mut self, parent: NodeId, child: NodeId) {
+        debug_assert!(self.valid_node_id(parent));
+        debug_assert!(self.valid_node_id(child));
+        debug_assert!(!self.is_ancestor_of(child, parent));
         // Set new parent
         self.nodes[child.0].parent = Some(parent);
         // Link into parent's child list
@@ -952,6 +963,12 @@ impl<'a> Document<'a> {
 
     /// Insert a child before a reference node. Both must share the same parent.
     pub fn insert_before(&mut self, parent: NodeId, new_child: NodeId, reference: NodeId) {
+        if new_child == reference
+            || !self.can_reparent(parent, new_child)
+            || self.parent(reference) != Some(parent)
+        {
+            return;
+        }
         self.detach(new_child);
         if let Some(node) = self.nodes.get_mut(new_child.0) {
             node.parent = Some(parent);
@@ -979,6 +996,12 @@ impl<'a> Document<'a> {
 
     /// Insert a child after a reference node.
     pub fn insert_after(&mut self, parent: NodeId, new_child: NodeId, reference: NodeId) {
+        if new_child == reference
+            || !self.can_reparent(parent, new_child)
+            || self.parent(reference) != Some(parent)
+        {
+            return;
+        }
         self.detach(new_child);
         if let Some(node) = self.nodes.get_mut(new_child.0) {
             node.parent = Some(parent);
@@ -1004,12 +1027,21 @@ impl<'a> Document<'a> {
     }
 
     /// Remove a child from its parent. The node remains in the arena but is detached.
-    pub fn remove_child(&mut self, _parent: NodeId, child: NodeId) {
+    pub fn remove_child(&mut self, parent: NodeId, child: NodeId) {
+        if self.parent(child) != Some(parent) {
+            return;
+        }
         self.detach(child);
     }
 
     /// Replace an old child with a new child under the given parent.
     pub fn replace_child(&mut self, parent: NodeId, new_child: NodeId, old_child: NodeId) {
+        if new_child == old_child
+            || !self.can_reparent(parent, new_child)
+            || self.parent(old_child) != Some(parent)
+        {
+            return;
+        }
         self.detach(new_child);
         let prev = self.nodes.get(old_child.0).and_then(|n| n.prev_sibling);
         let next = self.nodes.get(old_child.0).and_then(|n| n.next_sibling);
@@ -1076,6 +1108,33 @@ impl<'a> Document<'a> {
                 node.next_sibling = None;
             }
         }
+    }
+
+    fn valid_node_id(&self, id: NodeId) -> bool {
+        id.0 < self.nodes.len()
+    }
+
+    fn can_reparent(&self, parent: NodeId, child: NodeId) -> bool {
+        self.valid_node_id(parent)
+            && self.valid_node_id(child)
+            && parent != child
+            && !self.is_ancestor_of(child, parent)
+    }
+
+    fn is_ancestor_of(&self, maybe_ancestor: NodeId, node: NodeId) -> bool {
+        let mut current = Some(node);
+        let mut steps = 0usize;
+        while let Some(id) = current {
+            if id == maybe_ancestor {
+                return true;
+            }
+            if steps >= self.nodes.len() {
+                return true;
+            }
+            current = self.nodes.get(id.0).and_then(|n| n.parent);
+            steps += 1;
+        }
+        false
     }
 
     // ─── Navigation helpers ───
@@ -1196,8 +1255,10 @@ impl<'a> Document<'a> {
             }
             out.write_str("?>")?;
         }
-        if let Some(dt) = &self.doctype {
-            out.write_str(dt)?;
+        if opts.include_doctype {
+            if let Some(dt) = &self.doctype {
+                out.write_str(dt)?;
+            }
         }
         for child in self.children(self.root) {
             self.write_node_to(child, out, opts, 0, opts.indent.is_some())?;
@@ -1223,15 +1284,41 @@ impl<'a> Document<'a> {
                     write_indent(out, opts, depth)?;
                 }
                 out.write_char('<')?;
-                let pname = elem.name.prefixed_name();
+                let raw_pname = elem.name.prefixed_name();
+                let pname = crate::writer::safe_xml_qname(&raw_pname);
                 out.write_str(&pname)?;
-                // Namespace declarations
+                // Track names already emitted for this start tag so sanitized
+                // programmatic attributes cannot collide into duplicate XML.
+                let mut seen_attrs = Vec::new();
+                // Namespace declarations. Sanitized prefixes can collide (two
+                // distinct invalid prefixes both collapse to `_`), which would
+                // emit duplicate `xmlns:_` attributes and produce not-well-formed
+                // output. Disambiguate the prefix against names already emitted
+                // for this start tag so the result always re-parses.
                 for (prefix, uri) in &elem.namespace_declarations {
                     if prefix.is_empty() {
+                        // A default-namespace declaration has the fixed name
+                        // `xmlns`, which cannot be disambiguated; skip a
+                        // duplicate rather than emit a malformed document.
+                        if seen_attrs.iter().any(|name| name == "xmlns") {
+                            continue;
+                        }
+                        seen_attrs.push("xmlns".to_string());
                         out.write_str(" xmlns=\"")?;
                     } else {
+                        let safe = crate::writer::safe_xml_ncname(prefix).into_owned();
+                        let mut candidate = safe.clone();
+                        let mut suffix = 1usize;
+                        while seen_attrs
+                            .iter()
+                            .any(|name| name == &format!("xmlns:{}", candidate))
+                        {
+                            candidate = format!("{}_{}", safe, suffix);
+                            suffix += 1;
+                        }
+                        seen_attrs.push(format!("xmlns:{}", candidate));
                         out.write_str(" xmlns:")?;
-                        out.write_str(prefix)?;
+                        out.write_str(&candidate)?;
                         out.write_str("=\"")?;
                     }
                     write_escaped_attr(out, uri)?;
@@ -1240,7 +1327,8 @@ impl<'a> Document<'a> {
                 // Attributes
                 for attr in &elem.attributes {
                     out.write_char(' ')?;
-                    let aname = attr.name.prefixed_name();
+                    let raw_aname = attr.name.prefixed_name();
+                    let aname = crate::writer::unique_safe_xml_qname(&raw_aname, &mut seen_attrs);
                     out.write_str(&aname)?;
                     out.write_str("=\"")?;
                     write_escaped_attr(out, &attr.value)?;
@@ -1366,6 +1454,12 @@ pub struct XmlWriteOptions {
     /// Use `<foo></foo>` instead of `<foo/>` for empty elements.
     /// Required for W3C Canonical XML (C14N).
     pub expand_empty_elements: bool,
+    /// Include the raw DOCTYPE declaration when serializing.
+    ///
+    /// Disabled by default so parsed DTDs are not handed to downstream XML
+    /// processors unless the caller deliberately opts into trusted DTD
+    /// round-tripping.
+    pub include_doctype: bool,
 }
 
 impl XmlWriteOptions {
@@ -1374,6 +1468,7 @@ impl XmlWriteOptions {
         XmlWriteOptions {
             indent: None,
             expand_empty_elements: false,
+            include_doctype: false,
         }
     }
 
@@ -1382,12 +1477,19 @@ impl XmlWriteOptions {
         XmlWriteOptions {
             indent: Some(indent.into()),
             expand_empty_elements: false,
+            include_doctype: false,
         }
     }
 
     /// Set whether empty elements use expanded form (`<foo></foo>`).
     pub fn with_expand_empty_elements(mut self, expand: bool) -> Self {
         self.expand_empty_elements = expand;
+        self
+    }
+
+    /// Set whether the parsed raw DOCTYPE declaration is serialized.
+    pub fn with_doctype(mut self, include: bool) -> Self {
+        self.include_doctype = include;
         self
     }
 }
@@ -1424,7 +1526,7 @@ fn write_escaped_text(out: &mut dyn fmt::Write, s: &str) -> fmt::Result {
             '<' => out.write_str("&lt;")?,
             '>' => out.write_str("&gt;")?,
             '\r' => out.write_str("&#xD;")?,
-            _ => out.write_char(c)?,
+            _ => out.write_char(crate::writer::sanitized_xml_char(c))?,
         }
     }
     Ok(())
@@ -1450,7 +1552,7 @@ fn write_escaped_attr(out: &mut dyn fmt::Write, s: &str) -> fmt::Result {
             '\t' => out.write_str("&#x9;")?,
             '\n' => out.write_str("&#xA;")?,
             '\r' => out.write_str("&#xD;")?,
-            _ => out.write_char(c)?,
+            _ => out.write_char(crate::writer::sanitized_xml_char(c))?,
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,29 @@
 //!
 //! assert!(w.into_string().contains("<root"));
 //! ```
+//!
+//! # Resource limits
+//!
+//! To fail closed on hostile input, the parser enforces fixed resource caps
+//! by default (see [`parser`] for the associated constants and the
+//! `Parser::with_*` overrides):
+//!
+//! - **Element nesting depth** — capped at
+//!   [`DEFAULT_MAX_DEPTH`](parser::DEFAULT_MAX_DEPTH) (128). Documents nested
+//!   deeper are rejected with an error rather than risking a stack overflow.
+//! - **Entity expansion byte budget** — capped at
+//!   [`DEFAULT_MAX_ENTITY_EXPANSION`](parser::DEFAULT_MAX_ENTITY_EXPANSION)
+//!   (1 MiB). Total bytes produced by entity expansion per parse cannot
+//!   exceed this, defeating billion-laughs / quadratic-blowup amplification.
+//! - **Entity expansion nesting depth** — capped at
+//!   [`DEFAULT_MAX_ENTITY_DEPTH`](parser::DEFAULT_MAX_ENTITY_DEPTH) (256), so
+//!   a deep linear entity chain fails closed instead of overflowing the stack
+//!   even before the byte budget is reached.
+//!
+//! The depth and expansion-byte limits are configurable via builder methods
+//! on [`Parser`] ([`Parser::with_max_depth`] and
+//! [`Parser::with_max_entity_expansion`]) when a workload legitimately needs
+//! a different bound.
 
 /// Arena-based DOM representation of XML documents.
 pub mod dom;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,10 +171,19 @@ fn decode_xml_bytes(input: &[u8]) -> XmlResult<String> {
 
 /// Decode UTF-16 little-endian bytes to a String.
 fn decode_utf16_le(bytes: &[u8]) -> XmlResult<String> {
+    // A UTF-16 stream must be an exact sequence of 16-bit code units.
+    // Dropping an orphan trailing byte would silently accept truncated input.
+    if !bytes.len().is_multiple_of(2) {
+        return Err(XmlError::well_formedness(
+            "Invalid UTF-16 LE: odd number of bytes",
+            1,
+            1,
+        ));
+    }
+
     // Pair up bytes as u16 code units (little-endian)
     let code_units: Vec<u16> = bytes
         .chunks(2)
-        .filter(|chunk| chunk.len() == 2)
         .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
         .collect();
 
@@ -184,10 +193,19 @@ fn decode_utf16_le(bytes: &[u8]) -> XmlResult<String> {
 
 /// Decode UTF-16 big-endian bytes to a String.
 fn decode_utf16_be(bytes: &[u8]) -> XmlResult<String> {
+    // A UTF-16 stream must be an exact sequence of 16-bit code units.
+    // Dropping an orphan trailing byte would silently accept truncated input.
+    if !bytes.len().is_multiple_of(2) {
+        return Err(XmlError::well_formedness(
+            "Invalid UTF-16 BE: odd number of bytes",
+            1,
+            1,
+        ));
+    }
+
     // Pair up bytes as u16 code units (big-endian)
     let code_units: Vec<u16> = bytes
         .chunks(2)
-        .filter(|chunk| chunk.len() == 2)
         .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
         .collect();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,6 +37,16 @@ pub const DEFAULT_MAX_DEPTH: u32 = 128;
 /// [`Parser::with_max_entity_expansion`].
 pub const DEFAULT_MAX_ENTITY_EXPANSION: usize = 1 << 20;
 
+/// Maximum nesting depth for entity replacement-text expansion.
+///
+/// Entity expansion recurses once per nested reference. The byte budget
+/// ([`DEFAULT_MAX_ENTITY_EXPANSION`]) bounds total output but not recursion
+/// depth: a long *linear* chain of distinct entities (`e0 -> e1 -> … -> eN`)
+/// whose leaf is tiny expands to ~1 byte yet descends N frames, overflowing the
+/// stack (an uncatchable abort). This cap fails such chains closed with a normal
+/// error. The limit is far above any realistic document's entity nesting.
+pub const DEFAULT_MAX_ENTITY_DEPTH: usize = 256;
+
 /// The XML 1.0 parser.
 pub struct Parser {
     /// Whether to resolve namespaces during parsing.
@@ -576,7 +586,7 @@ fn parse_xml_declaration<'a>(cursor: &mut Cursor<'a>) -> XmlResult<XmlDeclaratio
     })
 }
 
-/// Validate an encoding name per XML 1.0 production [81]:
+/// Validate an encoding name per XML 1.0 production `[81]`:
 /// EncName ::= [A-Za-z] ([A-Za-z0-9._] | '-')*
 fn is_valid_encoding_name(name: &str) -> bool {
     if name.is_empty() {
@@ -906,6 +916,19 @@ fn expand_entity_value(
     line: usize,
     col: usize,
 ) -> XmlResult<String> {
+    // `seen.len()` is the current expansion depth (one entry pushed per nested
+    // reference). Cap it so a deep linear entity chain fails closed instead of
+    // overflowing the stack.
+    if seen.len() > DEFAULT_MAX_ENTITY_DEPTH {
+        return Err(XmlError::well_formedness(
+            format!(
+                "Entity expansion nested deeper than {}",
+                DEFAULT_MAX_ENTITY_DEPTH
+            ),
+            line,
+            col,
+        ));
+    }
     let mut result = String::new();
     let mut pos = 0;
     let bytes = value.as_bytes();
@@ -1015,6 +1038,18 @@ fn expand_entity_value_no_builtins(
     line: usize,
     col: usize,
 ) -> XmlResult<String> {
+    // See `expand_entity_value`: bound recursion depth to fail deep linear
+    // entity chains closed rather than overflowing the stack.
+    if seen.len() > DEFAULT_MAX_ENTITY_DEPTH {
+        return Err(XmlError::well_formedness(
+            format!(
+                "Entity expansion nested deeper than {}",
+                DEFAULT_MAX_ENTITY_DEPTH
+            ),
+            line,
+            col,
+        ));
+    }
     let mut result = String::new();
     let mut pos = 0;
     let bytes = value.as_bytes();
@@ -1373,7 +1408,7 @@ fn parse_pubid_literal(cursor: &mut Cursor) -> XmlResult<String> {
     Ok(value)
 }
 
-/// Check if a character is a valid PubidChar (XML 1.0 production [13]).
+/// Check if a character is a valid PubidChar (XML 1.0 production `[13]`).
 fn is_pubid_char(c: char) -> bool {
     matches!(c,
         ' ' | '\r' | '\n' |
@@ -2391,6 +2426,16 @@ fn parse_element<'a>(
         } else {
             QName::local(attr_name)
         };
+        if resolved_attrs.iter().any(|existing: &Attribute<'a>| {
+            existing.name.local_name == a_qname.local_name
+                && existing.name.namespace_uri.as_deref() == a_qname.namespace_uri.as_deref()
+        }) {
+            return Err(XmlError::well_formedness(
+                format!("Duplicate attribute: {}", a_qname),
+                cursor.line(),
+                cursor.column(),
+            ));
+        }
         resolved_attrs.push(Attribute {
             name: a_qname,
             value: attr_value,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -94,14 +94,12 @@ impl XmlWriter {
     /// assert_eq!(w.into_string(), r#"<div class="main" id="content">Hello</div>"#);
     /// ```
     pub fn start_element(&mut self, name: &str, attrs: &[(&str, &str)]) {
+        let name = safe_xml_qname(name);
         self.buf.push('<');
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
+        let mut seen_attrs = Vec::new();
         for &(key, val) in attrs {
-            self.buf.push(' ');
-            self.buf.push_str(key);
-            self.buf.push_str("=\"");
-            write_escaped_attr_to_string(&mut self.buf, val);
-            self.buf.push('"');
+            write_sanitized_attr_to_string(&mut self.buf, key, val, &mut seen_attrs);
         }
         self.buf.push('>');
     }
@@ -118,14 +116,12 @@ impl XmlWriter {
     /// assert_eq!(w.into_string(), "<br/>");
     /// ```
     pub fn empty_element(&mut self, name: &str, attrs: &[(&str, &str)]) {
+        let name = safe_xml_qname(name);
         self.buf.push('<');
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
+        let mut seen_attrs = Vec::new();
         for &(key, val) in attrs {
-            self.buf.push(' ');
-            self.buf.push_str(key);
-            self.buf.push_str("=\"");
-            write_escaped_attr_to_string(&mut self.buf, val);
-            self.buf.push('"');
+            write_sanitized_attr_to_string(&mut self.buf, key, val, &mut seen_attrs);
         }
         self.buf.push_str("/>");
     }
@@ -153,14 +149,17 @@ impl XmlWriter {
         K: AsRef<str>,
         V: AsRef<str>,
     {
+        let name = safe_xml_qname(name);
         self.buf.push('<');
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
+        let mut seen_attrs = Vec::new();
         for (key, val) in attrs {
-            self.buf.push(' ');
-            self.buf.push_str(key.as_ref());
-            self.buf.push_str("=\"");
-            write_escaped_attr_to_string(&mut self.buf, val.as_ref());
-            self.buf.push('"');
+            write_sanitized_attr_to_string(
+                &mut self.buf,
+                key.as_ref(),
+                val.as_ref(),
+                &mut seen_attrs,
+            );
         }
         self.buf.push('>');
     }
@@ -186,14 +185,17 @@ impl XmlWriter {
         K: AsRef<str>,
         V: AsRef<str>,
     {
+        let name = safe_xml_qname(name);
         self.buf.push('<');
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
+        let mut seen_attrs = Vec::new();
         for (key, val) in attrs {
-            self.buf.push(' ');
-            self.buf.push_str(key.as_ref());
-            self.buf.push_str("=\"");
-            write_escaped_attr_to_string(&mut self.buf, val.as_ref());
-            self.buf.push('"');
+            write_sanitized_attr_to_string(
+                &mut self.buf,
+                key.as_ref(),
+                val.as_ref(),
+                &mut seen_attrs,
+            );
         }
         self.buf.push_str("/>");
     }
@@ -202,24 +204,23 @@ impl XmlWriter {
     ///
     /// This is the form required by W3C Canonical XML (C14N).
     pub fn empty_element_expanded(&mut self, name: &str, attrs: &[(&str, &str)]) {
+        let name = safe_xml_qname(name);
         self.buf.push('<');
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
+        let mut seen_attrs = Vec::new();
         for &(key, val) in attrs {
-            self.buf.push(' ');
-            self.buf.push_str(key);
-            self.buf.push_str("=\"");
-            write_escaped_attr_to_string(&mut self.buf, val);
-            self.buf.push('"');
+            write_sanitized_attr_to_string(&mut self.buf, key, val, &mut seen_attrs);
         }
         self.buf.push_str("></");
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
         self.buf.push('>');
     }
 
     /// Close an element: `</name>`.
     pub fn end_element(&mut self, name: &str) {
+        let name = safe_xml_qname(name);
         self.buf.push_str("</");
-        self.buf.push_str(name);
+        self.buf.push_str(&name);
         self.buf.push('>');
     }
 
@@ -338,12 +339,13 @@ impl std::fmt::Display for XmlWriter {
 /// intent of the text is preserved; a human reading the comment sees the
 /// same words) but byte-inequivalent.
 pub(crate) fn sanitize_comment_content(s: &str) -> Cow<'_, str> {
-    if !s.contains("--") && !s.ends_with('-') {
+    if !s.contains("--") && !s.ends_with('-') && s.chars().all(is_xml_char) {
         return Cow::Borrowed(s);
     }
     let mut out = String::with_capacity(s.len() + 4);
     let mut prev_was_dash = false;
     for c in s.chars() {
+        let c = sanitized_xml_char(c);
         if c == '-' && prev_was_dash {
             out.push(' ');
         }
@@ -360,10 +362,21 @@ pub(crate) fn sanitize_comment_content(s: &str) -> Cow<'_, str> {
 /// is inserted between the `?` and `>` so the byte sequence no longer
 /// matches the parser's terminator scan.
 pub(crate) fn sanitize_pi_data(s: &str) -> Cow<'_, str> {
-    if !s.contains("?>") {
+    if !s.contains("?>") && s.chars().all(is_xml_char) {
         return Cow::Borrowed(s);
     }
-    Cow::Owned(s.replace("?>", "? >"))
+    let mut out = String::with_capacity(s.len() + 4);
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        let c = sanitized_xml_char(c);
+        if c == '?' && chars.peek() == Some(&'>') {
+            out.push('?');
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
 }
 
 /// Sanitize a PI target so it cannot collide with the reserved name
@@ -374,10 +387,19 @@ pub(crate) fn sanitize_pi_data(s: &str) -> Cow<'_, str> {
 /// reparse-rejected document. Renaming to `_xml` preserves the "this
 /// is a PI" intent while making the output unambiguously a PI node.
 pub(crate) fn sanitize_pi_target(s: &str) -> Cow<'_, str> {
+    // The reserved target `xml` (any case) is renamed so the PI cannot be
+    // mistaken for an XML declaration.
     if s.eq_ignore_ascii_case("xml") {
-        Cow::Owned(format!("_{}", s))
-    } else {
+        return Cow::Owned(format!("_{}", s));
+    }
+    // A PI target must be a valid XML Name. Without this check a target
+    // containing `?>` plus markup (e.g. `foo?><evil>`) is written verbatim
+    // between `<?` and the data, breaking out of PI position and smuggling
+    // sibling elements into the output. Any invalid target collapses to `_`.
+    if is_valid_xml_ncname(s) {
         Cow::Borrowed(s)
+    } else {
+        Cow::Borrowed("_")
     }
 }
 
@@ -391,10 +413,28 @@ pub(crate) fn sanitize_pi_target(s: &str) -> Cow<'_, str> {
 /// `<![CDATA[hello]]]]><![CDATA[>world]]>`, which reparses as two adjacent
 /// CDATA sections concatenating to `"hello]]>world"`.
 pub(crate) fn split_cdata_content(s: &str) -> Cow<'_, str> {
-    if !s.contains("]]>") {
+    if !s.contains("]]>") && s.chars().all(is_xml_char) {
         return Cow::Borrowed(s);
     }
-    Cow::Owned(s.replace("]]>", "]]]]><![CDATA[>"))
+    let sanitized: String = s.chars().map(sanitized_xml_char).collect();
+    Cow::Owned(sanitized.replace("]]>", "]]]]><![CDATA[>"))
+}
+
+pub(crate) fn sanitized_xml_char(c: char) -> char {
+    if is_xml_char(c) {
+        c
+    } else {
+        '\u{FFFD}'
+    }
+}
+
+pub(crate) fn is_xml_char(c: char) -> bool {
+    matches!(c,
+        '\u{9}' | '\u{A}' | '\u{D}' |
+        '\u{20}'..='\u{D7FF}' |
+        '\u{E000}'..='\u{FFFD}' |
+        '\u{10000}'..='\u{10FFFF}'
+    )
 }
 
 /// Return `s` if it is a version this library can both serialize and
@@ -441,6 +481,98 @@ fn is_valid_xml_encoding(s: &str) -> bool {
     bytes.all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
 }
 
+/// Return a safe XML QName for structural markup names. Invalid names are
+/// replaced by `_` so programmatic name input cannot break out of tag or
+/// attribute-name position and smuggle markup into serialized output.
+pub(crate) fn safe_xml_qname(s: &str) -> Cow<'_, str> {
+    if is_valid_xml_qname(s) {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Borrowed("_")
+    }
+}
+
+/// Return a safe XML NCName for namespace declaration prefixes.
+pub(crate) fn safe_xml_ncname(s: &str) -> Cow<'_, str> {
+    if is_valid_xml_ncname(s) {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Borrowed("_")
+    }
+}
+
+/// Return a safe XML QName that is unique among names already emitted for
+/// the same element.
+///
+/// Sanitization can collapse distinct invalid inputs such as `"bad attr"` and
+/// `"bad\tattr"` to the same fallback name (`"_"`). XML forbids duplicate
+/// attribute names, so callers pass a per-element `seen` set and this helper
+/// appends deterministic suffixes (`_1`, `_2`, ...) when needed.
+pub(crate) fn unique_safe_xml_qname(s: &str, seen: &mut Vec<String>) -> String {
+    let base = safe_xml_qname(s).into_owned();
+    if !seen.contains(&base) {
+        seen.push(base.clone());
+        return base;
+    }
+
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{}_{}", base, suffix);
+        if !seen.contains(&candidate) {
+            seen.push(candidate.clone());
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+pub(crate) fn is_valid_xml_qname(s: &str) -> bool {
+    let mut parts = s.split(':');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    let Some(second) = parts.next() else {
+        return is_valid_xml_ncname(first);
+    };
+    parts.next().is_none() && is_valid_xml_ncname(first) && is_valid_xml_ncname(second)
+}
+
+pub(crate) fn is_valid_xml_ncname(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_ncname_start_char(c) => {}
+        _ => return false,
+    }
+    chars.all(is_ncname_char)
+}
+
+/// XML 1.0 `NCNameStartChar` — the full `NameStartChar` production minus `:`.
+///
+/// Must mirror the parser's accepted ranges so that names produced by the
+/// parser round-trip through serialization without being sanitized to `_`
+/// (e.g. `<é/>`). Sanitization only exists to neutralize *invalid*
+/// programmatic names, not to reject valid non-ASCII ones.
+fn is_ncname_start_char(c: char) -> bool {
+    matches!(c,
+        'A'..='Z' | '_' | 'a'..='z' |
+        '\u{C0}'..='\u{D6}' | '\u{D8}'..='\u{F6}' |
+        '\u{F8}'..='\u{2FF}' | '\u{370}'..='\u{37D}' |
+        '\u{37F}'..='\u{1FFF}' | '\u{200C}'..='\u{200D}' |
+        '\u{2070}'..='\u{218F}' | '\u{2C00}'..='\u{2FEF}' |
+        '\u{3001}'..='\u{D7FF}' | '\u{F900}'..='\u{FDCF}' |
+        '\u{FDF0}'..='\u{FFFD}' | '\u{10000}'..='\u{EFFFF}'
+    )
+}
+
+/// XML 1.0 `NCNameChar` — the full `NameChar` production minus `:`.
+fn is_ncname_char(c: char) -> bool {
+    is_ncname_start_char(c)
+        || matches!(c,
+            '-' | '.' | '0'..='9' | '\u{B7}' |
+            '\u{0300}'..='\u{036F}' | '\u{203F}'..='\u{2040}'
+        )
+}
+
 // ─── Internal escaping helpers (write directly to String, no allocation) ───
 
 /// Write text content with XML escaping directly to a String.
@@ -451,7 +583,7 @@ fn write_escaped_text_to_string(buf: &mut String, s: &str) {
             '<' => buf.push_str("&lt;"),
             '>' => buf.push_str("&gt;"),
             '\r' => buf.push_str("&#xD;"),
-            _ => buf.push(c),
+            _ => buf.push(sanitized_xml_char(c)),
         }
     }
 }
@@ -467,9 +599,25 @@ fn write_escaped_attr_to_string(buf: &mut String, s: &str) {
             '\t' => buf.push_str("&#x9;"),
             '\n' => buf.push_str("&#xA;"),
             '\r' => buf.push_str("&#xD;"),
-            _ => buf.push(c),
+            _ => buf.push(sanitized_xml_char(c)),
         }
     }
+}
+
+/// Write one attribute after structural-name sanitization and per-element
+/// collision disambiguation.
+fn write_sanitized_attr_to_string(
+    buf: &mut String,
+    key: &str,
+    value: &str,
+    seen_attrs: &mut Vec<String>,
+) {
+    let key = unique_safe_xml_qname(key, seen_attrs);
+    buf.push(' ');
+    buf.push_str(&key);
+    buf.push_str("=\"");
+    write_escaped_attr_to_string(buf, value);
+    buf.push('"');
 }
 
 #[cfg(test)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -392,7 +392,7 @@ pub(crate) fn sanitize_pi_target(s: &str) -> Cow<'_, str> {
     if s.eq_ignore_ascii_case("xml") {
         return Cow::Owned(format!("_{}", s));
     }
-    // A PI target must be a valid XML Name. Without this check a target
+    // A PI target must be a valid XML NCName (no ':'). Without this check a target
     // containing `?>` plus markup (e.g. `foo?><evil>`) is written verbatim
     // between `<?` and the data, breaking out of PI position and smuggling
     // sibling elements into the output. Any invalid target collapses to `_`.

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1044,7 +1044,10 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
             }
-            Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
+            // `apply_step` already returns a deduplicated, document-ordered
+            // vector, so an extra dedup pass here would be redundant (and
+            // uncharged) work.
+            Ok(XPathValue::NodeSet(nodes))
         }
         Expr::AbsolutePath(steps) => {
             // Find the document root
@@ -1056,7 +1059,8 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
             }
-            Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
+            // Already deduplicated and document-ordered by `apply_step`.
+            Ok(XPathValue::NodeSet(nodes))
         }
         Expr::Union(left, right) => {
             let left_val = evaluate_expr(left, ctx)?;
@@ -1155,10 +1159,19 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
 /// work is not otherwise charged (the budget only covers node-set *building*).
 /// Without this, `(/r/a) = (/r/b)` over disjoint-valued sets built via cheap
 /// child-axis paths runs for minutes while staying under the node-visit cap.
+///
+/// Only node-set work is charged: a pure scalar-vs-scalar comparison (e.g.
+/// `1 = 1`) performs no node visits, so it must not consume budget — otherwise
+/// it would fail under a zero budget despite touching no nodes. Scalar-vs-node-set
+/// is charged as `1 * N`.
 fn charge_comparison(left: &XPathValue, right: &XPathValue, ctx: &EvalContext) -> XmlResult<()> {
-    let l = left.as_node_set().len().max(1);
-    let r = right.as_node_set().len().max(1);
-    ctx.budget.charge(l.saturating_mul(r))
+    let l = left.as_node_set().len();
+    let r = right.as_node_set().len();
+    if l == 0 && r == 0 {
+        // Neither operand is a (non-empty) node-set: no cartesian scan happens.
+        return Ok(());
+    }
+    ctx.budget.charge(l.max(1).saturating_mul(r.max(1)))
 }
 
 /// XPath equality comparison (handles node-set vs string/number/boolean).

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1286,12 +1286,7 @@ fn select_axis(axis: &Axis, node: NodeId, ctx: &EvalContext) -> XmlResult<Vec<No
             ctx.budget.charge(1)?;
             Ok(vec![node])
         }
-        Axis::DescendantOrSelf => {
-            let mut result = vec![node];
-            ctx.budget.charge(1)?;
-            result.extend(collect_descendants(doc, node, false, ctx.budget)?);
-            Ok(result)
-        }
+        Axis::DescendantOrSelf => collect_descendants(doc, node, true, ctx.budget),
         Axis::AncestorOrSelf => {
             let mut result = vec![node];
             result.extend(doc.ancestors(node));
@@ -1336,15 +1331,23 @@ fn collect_descendants(
     budget: &EvalBudget,
 ) -> XmlResult<Vec<NodeId>> {
     let mut result = Vec::new();
-    if include_self {
+    let mut stack = if include_self {
+        vec![node]
+    } else {
+        let mut children = doc.children(node);
+        children.reverse();
+        children
+    };
+
+    while let Some(current) = stack.pop() {
         budget.charge(1)?;
-        result.push(node);
+        result.push(current);
+
+        let mut children = doc.children(current);
+        children.reverse();
+        stack.extend(children);
     }
-    for child in doc.children(node) {
-        budget.charge(1)?;
-        result.push(child);
-        result.extend(collect_descendants(doc, child, false, budget)?);
-    }
+
     Ok(result)
 }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1241,16 +1241,16 @@ fn apply_step(step: &Step, context_nodes: &[NodeId], ctx: &EvalContext) -> XmlRe
     let mut result = Vec::new();
     for &node in context_nodes {
         let axis_nodes = select_axis(&step.axis, node, ctx)?;
+        let mut step_nodes = Vec::new();
         for &candidate in &axis_nodes {
             if matches_node_test(&step.node_test, candidate, ctx.doc, ctx.namespaces) {
-                result.push(candidate);
+                step_nodes.push(candidate);
             }
         }
-    }
-    // Apply predicates
-    for pred in &step.predicates {
-        result = apply_predicate(pred, &result, ctx)?;
-        result = dedup_document_order(result);
+        for pred in &step.predicates {
+            step_nodes = apply_predicate(pred, &step_nodes, ctx)?;
+        }
+        result.extend(step_nodes);
     }
     Ok(dedup_document_order(result))
 }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1043,7 +1043,6 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let mut nodes = vec![ctx.node];
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
-                nodes = dedup_document_order(nodes);
             }
             Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
         }
@@ -1056,7 +1055,6 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let mut nodes = vec![root];
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
-                nodes = dedup_document_order(nodes);
             }
             Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
         }
@@ -1757,20 +1755,26 @@ fn collect_elements_with_id(
     result: &mut Vec<NodeId>,
     budget: &EvalBudget,
 ) -> XmlResult<()> {
-    budget.charge(1)?;
-    if let Some(NodeKind::Element(e)) = doc.node_kind(node) {
-        for attr in &e.attributes {
-            if (&*attr.name.local_name == "id" || &*attr.name.local_name == "ID")
-                && ids.contains(&&*attr.value)
-            {
-                result.push(node);
-                break;
+    let mut stack = vec![node];
+
+    while let Some(current) = stack.pop() {
+        budget.charge(1)?;
+        if let Some(NodeKind::Element(e)) = doc.node_kind(current) {
+            for attr in &e.attributes {
+                if (&*attr.name.local_name == "id" || &*attr.name.local_name == "ID")
+                    && ids.contains(&&*attr.value)
+                {
+                    result.push(current);
+                    break;
+                }
             }
         }
+
+        let mut children = doc.children(current);
+        children.reverse();
+        stack.extend(children);
     }
-    for child in doc.children(node) {
-        collect_elements_with_id(doc, child, ids, result, budget)?;
-    }
+
     Ok(())
 }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -16,6 +16,7 @@
 //! - Operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `and`, `or`, `+`, `-`, `*`,
 //!   `div`, `mod`, `|`
 
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use crate::dom::{Document, NodeId, NodeKind};
@@ -133,6 +134,8 @@ pub struct XPathEvaluator {
     /// Maximum expression-nesting depth enforced by the parser. Defaults
     /// to [`DEFAULT_MAX_XPATH_DEPTH`]; override via [`Self::with_max_depth`].
     max_depth: u32,
+    /// Maximum number of axis/predicate node visits per evaluation.
+    max_node_visits: usize,
 }
 
 impl XPathEvaluator {
@@ -142,6 +145,7 @@ impl XPathEvaluator {
         XPathEvaluator {
             namespaces: HashMap::new(),
             max_depth: DEFAULT_MAX_XPATH_DEPTH,
+            max_node_visits: DEFAULT_MAX_XPATH_NODE_VISITS,
         }
     }
 
@@ -157,6 +161,13 @@ impl XPathEvaluator {
         self
     }
 
+    /// Override the maximum number of axis/predicate node visits permitted
+    /// during one evaluation.
+    pub fn with_max_node_visits(mut self, max_node_visits: usize) -> Self {
+        self.max_node_visits = max_node_visits;
+        self
+    }
+
     /// Evaluate an XPath expression from the given context node.
     pub fn evaluate(
         &self,
@@ -167,12 +178,14 @@ impl XPathEvaluator {
         let tokens = tokenize(expr)?;
         let mut parser = XPathParser::new(&tokens, self.max_depth);
         let ast = parser.parse_expr()?;
+        let budget = EvalBudget::new(self.max_node_visits);
         let ctx = EvalContext {
             node: context,
             position: 1,
             size: 1,
             doc,
             namespaces: &self.namespaces,
+            budget: &budget,
         };
         evaluate_expr(&ast, &ctx)
     }
@@ -533,6 +546,12 @@ enum NodeTest {
 /// exceeds 5-10 nesting levels). Override via
 /// [`XPathEvaluator::with_max_depth`].
 pub const DEFAULT_MAX_XPATH_DEPTH: u32 = 32;
+
+/// Default maximum axis/predicate node visits in one XPath evaluation.
+///
+/// The cap bounds hostile expressions such as repeated descendant/following
+/// axes over large DOMs while leaving ordinary document queries unaffected.
+pub const DEFAULT_MAX_XPATH_NODE_VISITS: usize = 100_000;
 
 struct XPathParser<'a> {
     tokens: &'a [Token],
@@ -987,6 +1006,35 @@ struct EvalContext<'a, 'b> {
     size: usize,
     doc: &'a Document<'b>,
     namespaces: &'a HashMap<String, String>,
+    budget: &'a EvalBudget,
+}
+
+struct EvalBudget {
+    /// Visits still available during this evaluation.
+    remaining: Cell<usize>,
+    /// The caller-configured cap, retained for stable diagnostics.
+    max_visits: usize,
+}
+
+impl EvalBudget {
+    fn new(max_visits: usize) -> Self {
+        Self {
+            remaining: Cell::new(max_visits),
+            max_visits,
+        }
+    }
+
+    fn charge(&self, amount: usize) -> XmlResult<()> {
+        let remaining = self.remaining.get();
+        if amount > remaining {
+            return Err(XmlError::xpath(format!(
+                "XPath evaluation exceeded maximum node visit budget of {}",
+                self.max_visits
+            )));
+        }
+        self.remaining.set(remaining - amount);
+        Ok(())
+    }
 }
 
 fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
@@ -995,6 +1043,7 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let mut nodes = vec![ctx.node];
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
+                nodes = dedup_document_order(nodes);
             }
             Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
         }
@@ -1007,6 +1056,7 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let mut nodes = vec![root];
             for step in steps {
                 nodes = apply_step(step, &nodes, ctx)?;
+                nodes = dedup_document_order(nodes);
             }
             Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
         }
@@ -1015,6 +1065,7 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let right_val = evaluate_expr(right, ctx)?;
             let mut nodes = left_val.as_node_set().to_vec();
             nodes.extend_from_slice(right_val.as_node_set());
+            ctx.budget.charge(nodes.len())?;
             Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
         }
         Expr::Or(left, right) => {
@@ -1036,11 +1087,13 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
         Expr::Eq(left, right) => {
             let l = evaluate_expr(left, ctx)?;
             let r = evaluate_expr(right, ctx)?;
+            charge_comparison(&l, &r, ctx)?;
             Ok(XPathValue::Boolean(xpath_equal(&l, &r, ctx.doc)))
         }
         Expr::NotEq(left, right) => {
             let l = evaluate_expr(left, ctx)?;
             let r = evaluate_expr(right, ctx)?;
+            charge_comparison(&l, &r, ctx)?;
             Ok(XPathValue::Boolean(!xpath_equal(&l, &r, ctx.doc)))
         }
         Expr::Lt(left, right) => {
@@ -1096,6 +1149,18 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
         Expr::NumberLiteral(n) => Ok(XPathValue::Number(*n)),
         Expr::FunctionCall(name, args) => evaluate_function(name, args, ctx),
     }
+}
+
+/// Charge the evaluation budget for an `=`/`!=` comparison.
+///
+/// Node-set comparison is an O(n*m) cartesian scan over string-values, and that
+/// work is not otherwise charged (the budget only covers node-set *building*).
+/// Without this, `(/r/a) = (/r/b)` over disjoint-valued sets built via cheap
+/// child-axis paths runs for minutes while staying under the node-visit cap.
+fn charge_comparison(left: &XPathValue, right: &XPathValue, ctx: &EvalContext) -> XmlResult<()> {
+    let l = left.as_node_set().len().max(1);
+    let r = right.as_node_set().len().max(1);
+    ctx.budget.charge(l.saturating_mul(r))
 }
 
 /// XPath equality comparison (handles node-set vs string/number/boolean).
@@ -1157,18 +1222,20 @@ fn xpath_equal(left: &XPathValue, right: &XPathValue, doc: &Document<'_>) -> boo
 fn apply_step(step: &Step, context_nodes: &[NodeId], ctx: &EvalContext) -> XmlResult<Vec<NodeId>> {
     let mut result = Vec::new();
     for &node in context_nodes {
-        let axis_nodes = select_axis(&step.axis, node, ctx.doc);
+        let axis_nodes = select_axis(&step.axis, node, ctx)?;
         for &candidate in &axis_nodes {
             if matches_node_test(&step.node_test, candidate, ctx.doc, ctx.namespaces) {
                 result.push(candidate);
             }
         }
     }
+    ctx.budget.charge(result.len())?;
     // Apply predicates
     for pred in &step.predicates {
         result = apply_predicate(pred, &result, ctx)?;
+        result = dedup_document_order(result);
     }
-    Ok(result)
+    Ok(dedup_document_order(result))
 }
 
 fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResult<Vec<NodeId>> {
@@ -1181,6 +1248,7 @@ fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResul
             size,
             doc: ctx.doc,
             namespaces: ctx.namespaces,
+            budget: ctx.budget,
         };
         let val = evaluate_expr(pred, &pred_ctx)?;
         let keep = match &val {
@@ -1191,58 +1259,107 @@ fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResul
             result.push(node);
         }
     }
+    ctx.budget.charge(nodes.len() + result.len())?;
     Ok(result)
 }
 
-fn select_axis(axis: &Axis, node: NodeId, doc: &Document<'_>) -> Vec<NodeId> {
+fn select_axis(axis: &Axis, node: NodeId, ctx: &EvalContext) -> XmlResult<Vec<NodeId>> {
+    let doc = ctx.doc;
     match axis {
-        Axis::Child => doc.children(node),
-        Axis::Descendant => doc.descendants(node),
-        Axis::Parent => doc.parent(node).into_iter().collect(),
-        Axis::Ancestor => doc.ancestors(node),
-        Axis::Self_ => vec![node],
+        Axis::Child => {
+            let nodes = doc.children(node);
+            ctx.budget.charge(nodes.len())?;
+            Ok(nodes)
+        }
+        Axis::Descendant => collect_descendants(doc, node, false, ctx.budget),
+        Axis::Parent => {
+            let nodes: Vec<_> = doc.parent(node).into_iter().collect();
+            ctx.budget.charge(nodes.len())?;
+            Ok(nodes)
+        }
+        Axis::Ancestor => {
+            let nodes = doc.ancestors(node);
+            ctx.budget.charge(nodes.len())?;
+            Ok(nodes)
+        }
+        Axis::Self_ => {
+            ctx.budget.charge(1)?;
+            Ok(vec![node])
+        }
         Axis::DescendantOrSelf => {
             let mut result = vec![node];
-            result.extend(doc.descendants(node));
-            result
+            ctx.budget.charge(1)?;
+            result.extend(collect_descendants(doc, node, false, ctx.budget)?);
+            Ok(result)
         }
         Axis::AncestorOrSelf => {
             let mut result = vec![node];
             result.extend(doc.ancestors(node));
-            result
+            ctx.budget.charge(result.len())?;
+            Ok(result)
         }
         Axis::FollowingSibling => {
             let mut result = Vec::new();
             let mut current = doc.next_sibling(node);
             while let Some(sib) = current {
+                ctx.budget.charge(1)?;
                 result.push(sib);
                 current = doc.next_sibling(sib);
             }
-            result
+            Ok(result)
         }
         Axis::PrecedingSibling => {
             let mut result = Vec::new();
             let mut current = doc.previous_sibling(node);
             while let Some(sib) = current {
+                ctx.budget.charge(1)?;
                 result.push(sib);
                 current = doc.previous_sibling(sib);
             }
-            result
+            Ok(result)
         }
-        Axis::Following => collect_following(doc, node),
-        Axis::Preceding => collect_preceding(doc, node),
-        Axis::Attribute => doc.get_attribute_nodes(node).to_vec(),
-        Axis::Namespace => Vec::new(),
+        Axis::Following => collect_following(doc, node, ctx.budget),
+        Axis::Preceding => collect_preceding(doc, node, ctx.budget),
+        Axis::Attribute => {
+            let nodes = doc.get_attribute_nodes(node).to_vec();
+            ctx.budget.charge(nodes.len())?;
+            Ok(nodes)
+        }
+        Axis::Namespace => Ok(Vec::new()),
     }
 }
 
-fn collect_following(doc: &Document<'_>, node: NodeId) -> Vec<NodeId> {
+fn collect_descendants(
+    doc: &Document<'_>,
+    node: NodeId,
+    include_self: bool,
+    budget: &EvalBudget,
+) -> XmlResult<Vec<NodeId>> {
+    let mut result = Vec::new();
+    if include_self {
+        budget.charge(1)?;
+        result.push(node);
+    }
+    for child in doc.children(node) {
+        budget.charge(1)?;
+        result.push(child);
+        result.extend(collect_descendants(doc, child, false, budget)?);
+    }
+    Ok(result)
+}
+
+fn collect_following(
+    doc: &Document<'_>,
+    node: NodeId,
+    budget: &EvalBudget,
+) -> XmlResult<Vec<NodeId>> {
     let mut result = Vec::new();
     let mut current = node;
     loop {
         if let Some(next) = doc.next_sibling(current) {
+            budget.charge(1)?;
             result.push(next);
-            result.extend(doc.descendants(next));
+            result.extend(collect_descendants(doc, next, false, budget)?);
             current = next;
             continue;
         }
@@ -1252,18 +1369,23 @@ fn collect_following(doc: &Document<'_>, node: NodeId) -> Vec<NodeId> {
             break;
         }
     }
-    result
+    Ok(result)
 }
 
-fn collect_preceding(doc: &Document<'_>, node: NodeId) -> Vec<NodeId> {
+fn collect_preceding(
+    doc: &Document<'_>,
+    node: NodeId,
+    budget: &EvalBudget,
+) -> XmlResult<Vec<NodeId>> {
     let mut result = Vec::new();
     let mut current = node;
     loop {
         if let Some(prev) = doc.previous_sibling(current) {
-            let descs = doc.descendants(prev);
+            let descs = collect_descendants(doc, prev, false, budget)?;
             for d in descs.into_iter().rev() {
                 result.push(d);
             }
+            budget.charge(1)?;
             result.push(prev);
             current = prev;
             continue;
@@ -1278,7 +1400,7 @@ fn collect_preceding(doc: &Document<'_>, node: NodeId) -> Vec<NodeId> {
             break;
         }
     }
-    result
+    Ok(result)
 }
 
 fn matches_node_test(
@@ -1293,8 +1415,12 @@ fn matches_node_test(
             Some(NodeKind::Element(_)) | Some(NodeKind::Attribute(_, _))
         ),
         NodeTest::Name(name) => match doc.node_kind(node) {
-            Some(NodeKind::Element(e)) => *e.name.local_name == *name,
-            Some(NodeKind::Attribute(qn, _)) => *qn.local_name == *name,
+            Some(NodeKind::Element(e)) => {
+                *e.name.local_name == *name && e.name.namespace_uri.is_none()
+            }
+            Some(NodeKind::Attribute(qn, _)) => {
+                *qn.local_name == *name && qn.namespace_uri.is_none()
+            }
             _ => false,
         },
         NodeTest::PrefixedName(prefix, local) => match doc.node_kind(node) {
@@ -1303,8 +1429,7 @@ fn matches_node_test(
                     *e.name.local_name == *local
                         && e.name.namespace_uri.as_deref() == Some(expected_ns.as_str())
                 } else {
-                    e.name.prefix.as_deref() == Some(prefix.as_str())
-                        && *e.name.local_name == *local
+                    false
                 }
             }
             Some(NodeKind::Attribute(qn, _)) => {
@@ -1312,7 +1437,7 @@ fn matches_node_test(
                     *qn.local_name == *local
                         && qn.namespace_uri.as_deref() == Some(expected_ns.as_str())
                 } else {
-                    qn.prefix.as_deref() == Some(prefix.as_str()) && *qn.local_name == *local
+                    false
                 }
             }
             _ => false,
@@ -1322,14 +1447,14 @@ fn matches_node_test(
                 if let Some(expected_ns) = namespaces.get(prefix) {
                     e.name.namespace_uri.as_deref() == Some(expected_ns.as_str())
                 } else {
-                    e.name.prefix.as_deref() == Some(prefix.as_str())
+                    false
                 }
             }
             Some(NodeKind::Attribute(qn, _)) => {
                 if let Some(expected_ns) = namespaces.get(prefix) {
                     qn.namespace_uri.as_deref() == Some(expected_ns.as_str())
                 } else {
-                    qn.prefix.as_deref() == Some(prefix.as_str())
+                    false
                 }
             }
             _ => false,
@@ -1463,8 +1588,12 @@ fn evaluate_function(name: &str, args: &[Expr], ctx: &EvalContext) -> XmlResult<
             let start = start.max(0) as usize;
             if args.len() == 3 {
                 let len = evaluate_expr(&args[2], ctx)?.to_number(ctx.doc).round() as usize;
-                let end = (start + len).min(chars.len());
-                let result: String = chars[start.min(chars.len())..end].iter().collect();
+                let begin = start.min(chars.len());
+                // `saturating_add` avoids the usize overflow that a huge/`inf`
+                // length argument would otherwise cause (debug panic / release
+                // wrap into an out-of-order slice).
+                let end = start.saturating_add(len).min(chars.len()).max(begin);
+                let result: String = chars[begin..end].iter().collect();
                 Ok(XPathValue::String(result))
             } else {
                 let result: String = chars[start.min(chars.len())..].iter().collect();

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1276,7 +1276,7 @@ fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResul
             result.push(node);
         }
     }
-    ctx.budget.charge(nodes.len() + result.len())?;
+    ctx.budget.charge(nodes.len())?;
     Ok(result)
 }
 

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1736,8 +1736,11 @@ fn evaluate_function(name: &str, args: &[Expr], ctx: &EvalContext) -> XmlResult<
             }
             let val = evaluate_expr(&args[0], ctx)?.to_string_value(ctx.doc);
             let ids: Vec<&str> = val.split_whitespace().collect();
+            if ids.is_empty() {
+                return Ok(XPathValue::NodeSet(Vec::new()));
+            }
             let mut result = Vec::new();
-            collect_elements_with_id(ctx.doc, ctx.doc.root(), &ids, &mut result);
+            collect_elements_with_id(ctx.doc, ctx.doc.root(), &ids, &mut result, ctx.budget)?;
             Ok(XPathValue::NodeSet(result))
         }
         _ => Err(XmlError::xpath(format!("Unknown function: {}()", name))),
@@ -1749,7 +1752,9 @@ fn collect_elements_with_id(
     node: NodeId,
     ids: &[&str],
     result: &mut Vec<NodeId>,
-) {
+    budget: &EvalBudget,
+) -> XmlResult<()> {
+    budget.charge(1)?;
     if let Some(NodeKind::Element(e)) = doc.node_kind(node) {
         for attr in &e.attributes {
             if (&*attr.name.local_name == "id" || &*attr.name.local_name == "ID")
@@ -1761,8 +1766,9 @@ fn collect_elements_with_id(
         }
     }
     for child in doc.children(node) {
-        collect_elements_with_id(doc, child, ids, result);
+        collect_elements_with_id(doc, child, ids, result, budget)?;
     }
+    Ok(())
 }
 
 /// Remove duplicate NodeIds and maintain document order.

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1227,7 +1227,6 @@ fn apply_step(step: &Step, context_nodes: &[NodeId], ctx: &EvalContext) -> XmlRe
             }
         }
     }
-    ctx.budget.charge(result.len())?;
     // Apply predicates
     for pred in &step.predicates {
         result = apply_predicate(pred, &result, ctx)?;

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -17,7 +17,7 @@
 //!   `div`, `mod`, `|`
 
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::{XmlError, XmlResult};
@@ -1257,6 +1257,11 @@ fn apply_step(step: &Step, context_nodes: &[NodeId], ctx: &EvalContext) -> XmlRe
 
 fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResult<Vec<NodeId>> {
     let size = nodes.len();
+    // Charge the candidate scan up front so a query that is already over budget
+    // fails before doing the (potentially expensive) per-candidate predicate
+    // evaluation, rather than after. This tightens the DoS bound the budget
+    // is meant to provide.
+    ctx.budget.charge(size)?;
     let mut result = Vec::new();
     for (i, &node) in nodes.iter().enumerate() {
         let pred_ctx = EvalContext {
@@ -1276,7 +1281,6 @@ fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResul
             result.push(node);
         }
     }
-    ctx.budget.charge(nodes.len())?;
     Ok(result)
 }
 
@@ -1799,12 +1803,53 @@ fn collect_elements_with_id(
 
 /// Remove duplicate NodeIds and return them in the document's current tree order.
 fn dedup_document_order(doc: &Document<'_>, mut nodes: Vec<NodeId>) -> Vec<NodeId> {
-    nodes.sort_by_cached_key(|&node| document_order_key(doc, node));
+    // A sibling-index memo turns each `position()` lookup from an O(siblings)
+    // scan into an amortized O(1) hash lookup. Without it, sorting a wide
+    // node-set is O(n^2) (each of n nodes re-scans its parent's child list),
+    // which is *uncharged* work that defeats the node-visit budget — a
+    // disjoint `(/r/a) = (/r/b)` comparison would spend minutes inside dedup
+    // before the comparison charge ever fires.
+    let mut order = SiblingOrderIndex::default();
+    nodes.sort_by_cached_key(|&node| document_order_key(doc, node, &mut order));
     nodes.dedup();
     nodes
 }
 
-fn document_order_key(doc: &Document<'_>, node: NodeId) -> (u8, Vec<(u8, usize)>, usize) {
+/// Memoizes the position of each node within its parent's child / attribute
+/// list. The first lookup for a given parent indexes that parent's whole list
+/// once; subsequent sibling lookups are O(1).
+#[derive(Default)]
+struct SiblingOrderIndex {
+    pos: HashMap<NodeId, usize>,
+    children_indexed: HashSet<NodeId>,
+    attrs_indexed: HashSet<NodeId>,
+}
+
+impl SiblingOrderIndex {
+    fn child_pos(&mut self, doc: &Document<'_>, parent: NodeId, child: NodeId) -> Option<usize> {
+        if self.children_indexed.insert(parent) {
+            for (i, c) in doc.children(parent).into_iter().enumerate() {
+                self.pos.insert(c, i);
+            }
+        }
+        self.pos.get(&child).copied()
+    }
+
+    fn attr_pos(&mut self, doc: &Document<'_>, parent: NodeId, attr: NodeId) -> Option<usize> {
+        if self.attrs_indexed.insert(parent) {
+            for (i, a) in doc.get_attribute_nodes(parent).iter().enumerate() {
+                self.pos.insert(*a, i);
+            }
+        }
+        self.pos.get(&attr).copied()
+    }
+}
+
+fn document_order_key(
+    doc: &Document<'_>,
+    node: NodeId,
+    order: &mut SiblingOrderIndex,
+) -> (u8, Vec<(u8, usize)>, usize) {
     let mut path = Vec::new();
     let mut current = node;
 
@@ -1819,20 +1864,12 @@ fn document_order_key(doc: &Document<'_>, node: NodeId) -> (u8, Vec<(u8, usize)>
         };
 
         if matches!(doc.node_kind(current), Some(NodeKind::Attribute(_, _))) {
-            let Some(index) = doc
-                .get_attribute_nodes(parent)
-                .iter()
-                .position(|&attr| attr == current)
-            else {
+            let Some(index) = order.attr_pos(doc, parent, current) else {
                 return (1, Vec::new(), node.index());
             };
             path.push((0, index));
         } else {
-            let Some(index) = doc
-                .children(parent)
-                .iter()
-                .position(|&child| child == current)
-            else {
+            let Some(index) = order.child_pos(doc, parent, current) else {
                 return (1, Vec::new(), node.index());
             };
             path.push((1, index));

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1160,18 +1160,25 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
 /// Without this, `(/r/a) = (/r/b)` over disjoint-valued sets built via cheap
 /// child-axis paths runs for minutes while staying under the node-visit cap.
 ///
-/// Only node-set work is charged: a pure scalar-vs-scalar comparison (e.g.
-/// `1 = 1`) performs no node visits, so it must not consume budget — otherwise
-/// it would fail under a zero budget despite touching no nodes. Scalar-vs-node-set
-/// is charged as `1 * N`.
+/// Only node-set work is charged, matching the actual number of string-value
+/// scans the comparison performs:
+/// - node-set vs node-set: `n * m`
+/// - node-set vs scalar: `n` (the scalar is converted once, then scanned against
+///   each node)
+/// - scalar vs scalar: `0` (no node visits — e.g. `1 = 1` must not consume budget,
+///   otherwise it would fail under a zero budget despite touching no nodes)
+///
+/// The operands are matched on their enum variants rather than via
+/// `as_node_set().len()`, because that helper returns an empty slice for *both* a
+/// scalar and an empty node-set. An empty node-set short-circuits the comparison
+/// with zero scans, so it must charge `0`, not be billed as a 1-wide scalar.
 fn charge_comparison(left: &XPathValue, right: &XPathValue, ctx: &EvalContext) -> XmlResult<()> {
-    let l = left.as_node_set().len();
-    let r = right.as_node_set().len();
-    if l == 0 && r == 0 {
-        // Neither operand is a (non-empty) node-set: no cartesian scan happens.
-        return Ok(());
-    }
-    ctx.budget.charge(l.max(1).saturating_mul(r.max(1)))
+    let cost = match (left, right) {
+        (XPathValue::NodeSet(a), XPathValue::NodeSet(b)) => a.len().saturating_mul(b.len()),
+        (XPathValue::NodeSet(ns), _) | (_, XPathValue::NodeSet(ns)) => ns.len(),
+        _ => 0,
+    };
+    ctx.budget.charge(cost)
 }
 
 /// XPath equality comparison (handles node-set vs string/number/boolean).

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1068,7 +1068,7 @@ fn evaluate_expr(expr: &Expr, ctx: &EvalContext) -> XmlResult<XPathValue> {
             let mut nodes = left_val.as_node_set().to_vec();
             nodes.extend_from_slice(right_val.as_node_set());
             ctx.budget.charge(nodes.len())?;
-            Ok(XPathValue::NodeSet(dedup_document_order(nodes)))
+            Ok(XPathValue::NodeSet(dedup_document_order(ctx.doc, nodes)))
         }
         Expr::Or(left, right) => {
             let l = evaluate_expr(left, ctx)?.to_boolean();
@@ -1252,7 +1252,7 @@ fn apply_step(step: &Step, context_nodes: &[NodeId], ctx: &EvalContext) -> XmlRe
         }
         result.extend(step_nodes);
     }
-    Ok(dedup_document_order(result))
+    Ok(dedup_document_order(ctx.doc, result))
 }
 
 fn apply_predicate(pred: &Expr, nodes: &[NodeId], ctx: &EvalContext) -> XmlResult<Vec<NodeId>> {
@@ -1797,11 +1797,49 @@ fn collect_elements_with_id(
     Ok(())
 }
 
-/// Remove duplicate NodeIds and maintain document order.
-fn dedup_document_order(mut nodes: Vec<NodeId>) -> Vec<NodeId> {
-    nodes.sort_by_key(|n| n.0);
+/// Remove duplicate NodeIds and return them in the document's current tree order.
+fn dedup_document_order(doc: &Document<'_>, mut nodes: Vec<NodeId>) -> Vec<NodeId> {
+    nodes.sort_by_cached_key(|&node| document_order_key(doc, node));
     nodes.dedup();
     nodes
+}
+
+fn document_order_key(doc: &Document<'_>, node: NodeId) -> (u8, Vec<(u8, usize)>, usize) {
+    let mut path = Vec::new();
+    let mut current = node;
+
+    loop {
+        if current == doc.root() {
+            path.reverse();
+            return (0, path, node.index());
+        }
+
+        let Some(parent) = doc.parent(current) else {
+            return (1, Vec::new(), node.index());
+        };
+
+        if matches!(doc.node_kind(current), Some(NodeKind::Attribute(_, _))) {
+            let Some(index) = doc
+                .get_attribute_nodes(parent)
+                .iter()
+                .position(|&attr| attr == current)
+            else {
+                return (1, Vec::new(), node.index());
+            };
+            path.push((0, index));
+        } else {
+            let Some(index) = doc
+                .children(parent)
+                .iter()
+                .position(|&child| child == current)
+            else {
+                return (1, Vec::new(), node.index());
+            };
+            path.push((1, index));
+        }
+
+        current = parent;
+    }
 }
 
 #[cfg(test)]

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -144,7 +144,12 @@ impl XsdValidator {
                         if let Some(name) = attr_elem.get_attribute("name") {
                             let type_ref = if let Some(type_attr) = attr_elem.get_attribute("type")
                             {
-                                resolve_type_name(type_attr, &validator.target_namespace)
+                                resolve_type_name(
+                                    schema_doc,
+                                    child,
+                                    type_attr,
+                                    &validator.target_namespace,
+                                )?
                             } else {
                                 // Check for inline simpleType child
                                 let mut inline_type = None;
@@ -285,7 +290,12 @@ impl XsdValidator {
                                 let type_ref = if let Some(type_attr) =
                                     attr_elem.get_attribute("type")
                                 {
-                                    resolve_type_name(type_attr, &validator.target_namespace)
+                                    resolve_type_name(
+                                        schema_doc,
+                                        child,
+                                        type_attr,
+                                        &validator.target_namespace,
+                                    )?
                                 } else {
                                     // Check for inline simpleType child
                                     let mut inline_type = None;

--- a/src/xsd/composition.rs
+++ b/src/xsd/composition.rs
@@ -21,7 +21,12 @@
 //!    group or attributeGroup references may have changed.
 
 use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::{XmlError, XmlResult};
@@ -55,6 +60,34 @@ pub(super) struct CompositionState {
     pub(super) depth: u8,
 }
 
+struct ResolvedSchemaPath {
+    path: PathBuf,
+    identity: Option<FileIdentity>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileIdentity {
+    dev: u64,
+    ino: u64,
+    ctime: i64,
+    ctime_nsec: i64,
+}
+
+#[cfg(unix)]
+fn file_identity(metadata: &fs::Metadata) -> Option<FileIdentity> {
+    Some(FileIdentity {
+        dev: metadata.dev(),
+        ino: metadata.ino(),
+        ctime: metadata.ctime(),
+        ctime_nsec: metadata.ctime_nsec(),
+    })
+}
+
+#[cfg(not(unix))]
+fn file_identity(_metadata: &fs::Metadata) -> Option<FileIdentity> {
+    None
+}
+
 impl CompositionState {
     /// Fresh state, seeded with the top-level schema's canonical path so
     /// the very first include won't try to re-load the outer document.
@@ -70,14 +103,14 @@ impl CompositionState {
 }
 
 /// Resolve a `schemaLocation` attribute to a filesystem path, applying
-/// F-10 containment, F-11 cycle detection, and the F-12 / TOCTOU fix in
-/// a single canonicalize step.
+/// F-10 containment, F-11 cycle detection, and the first half of the
+/// F-12 TOCTOU defense.
 ///
 /// Returns:
-/// * `Ok(Some(canonical))` — load this path. The returned `PathBuf` has
-///   already been canonicalized (symlinks resolved), so the caller can
-///   pass it directly to `std::fs::read_to_string` without a race
-///   between the containment check and the read.
+/// * `Ok(Some(resolved))` — load this path through `read_resolved_schema`,
+///   not directly. The path has been canonicalized and paired with the file
+///   identity observed during resolution so the read side can detect a later
+///   symlink swap before trusting bytes from the opened handle.
 /// * `Ok(None)` — silent-skip: either the target doesn't exist (matches
 ///   pre-fix behaviour for relative `schemaLocation` typos) or the file
 ///   was already loaded earlier in this build (cycle short-circuit).
@@ -90,7 +123,7 @@ fn resolve_include_path(
     canonical_base: Option<&Path>,
     state: &mut CompositionState,
     kind: &str,
-) -> XmlResult<Option<PathBuf>> {
+) -> XmlResult<Option<ResolvedSchemaPath>> {
     let resolved_path = match base_dir {
         Some(dir) => dir.join(schema_location),
         None => PathBuf::from(schema_location),
@@ -128,12 +161,39 @@ fn resolve_include_path(
         }
     }
 
-    // Prefer the canonical path for the subsequent read — that path has
-    // had its symlinks resolved, so a concurrent symlink swap cannot
-    // redirect the read outside the containment check we just passed.
-    // Fall back to the lexical `resolved_path` only when there's no
-    // containment to enforce (no base_dir), which is the pre-fix shape.
-    Ok(Some(canonical.unwrap_or(resolved_path)))
+    let path = canonical.unwrap_or(resolved_path);
+    let identity = fs::metadata(&path).ok().and_then(|m| file_identity(&m));
+    Ok(Some(ResolvedSchemaPath { path, identity }))
+}
+
+fn read_resolved_schema(
+    resolved: &ResolvedSchemaPath,
+    schema_location: &str,
+    kind: &str,
+) -> XmlResult<Option<String>> {
+    let mut file = match File::open(&resolved.path) {
+        Ok(file) => file,
+        Err(_) => return Ok(None),
+    };
+
+    if let Some(expected) = resolved.identity {
+        let actual = file
+            .metadata()
+            .ok()
+            .and_then(|metadata| file_identity(&metadata));
+        if actual != Some(expected) {
+            return Err(XmlError::validation(format!(
+                "Cannot resolve {} schemaLocation '{}': file changed during resolution",
+                kind, schema_location
+            )));
+        }
+    }
+
+    let mut contents = String::new();
+    match file.read_to_string(&mut contents) {
+        Ok(_) => Ok(Some(contents)),
+        Err(_) => Ok(None),
+    }
 }
 
 /// Process `xs:include`, `xs:redefine`, and `xs:import` elements in a schema
@@ -196,12 +256,13 @@ pub(super) fn process_schema_composition(
                         None => continue, // No schemaLocation, skip
                     };
 
-                    // Resolve the schemaLocation to a canonical path,
-                    // enforcing F-10 containment, F-11 cycle detection,
-                    // and closing the TOCTOU window against concurrent
-                    // symlink swaps (F-12) in a single helper.
+                    // Resolve the schemaLocation to a contained canonical path
+                    // and remember the resolved file identity. The subsequent
+                    // read verifies the opened handle still has that identity;
+                    // the race is closed by the resolve/read pair, not by this
+                    // path helper alone.
                     let kind = if is_redefine { "redefine" } else { "include" };
-                    let canonical_path = match resolve_include_path(
+                    let resolved_schema = match resolve_include_path(
                         schema_location,
                         base_dir,
                         canonical_base.as_deref(),
@@ -212,13 +273,17 @@ pub(super) fn process_schema_composition(
                         None => continue,
                     };
 
-                    // Load and parse the external schema from the
-                    // canonicalized path — symlinks already resolved,
-                    // so the read can't be redirected after the check.
-                    let ext_str = match std::fs::read_to_string(&canonical_path) {
-                        Ok(s) => s,
-                        Err(_) => continue,
-                    };
+                    // Load through the resolved descriptor. Canonicalization
+                    // proves the path was contained at check time; on Unix the
+                    // stored file identity also proves the opened handle is the
+                    // same file, closing the symlink-swap race. Other platforms
+                    // retain canonical containment but need platform handle APIs
+                    // for the same post-open identity guarantee.
+                    let ext_str =
+                        match read_resolved_schema(&resolved_schema, schema_location, kind)? {
+                            Some(s) => s,
+                            None => continue,
+                        };
                     let ext_doc = match crate::parse(&ext_str) {
                         Ok(d) => d,
                         Err(_) => continue,
@@ -233,7 +298,7 @@ pub(super) fn process_schema_composition(
                     state.depth += 1;
                     let ext_validator_res = XsdValidator::from_schema_with_composition_state(
                         &ext_doc,
-                        Some(&canonical_path),
+                        Some(&resolved_schema.path),
                         state,
                     );
                     state.depth -= 1;
@@ -265,7 +330,7 @@ pub(super) fn process_schema_composition(
                     };
 
                     // Same resolve-then-read sequence as include/redefine.
-                    let canonical_path = match resolve_include_path(
+                    let resolved_schema = match resolve_include_path(
                         schema_location,
                         base_dir,
                         canonical_base.as_deref(),
@@ -276,11 +341,14 @@ pub(super) fn process_schema_composition(
                         None => continue,
                     };
 
-                    // Load and parse the external schema.
-                    let ext_str = match std::fs::read_to_string(&canonical_path) {
-                        Ok(s) => s,
-                        Err(_) => continue,
-                    };
+                    // Load and parse the external schema, verifying after open
+                    // that the handle still matches the resolved file identity
+                    // where the platform exposes one through std.
+                    let ext_str =
+                        match read_resolved_schema(&resolved_schema, schema_location, "import")? {
+                            Some(s) => s,
+                            None => continue,
+                        };
                     let ext_doc = match crate::parse(&ext_str) {
                         Ok(d) => d,
                         Err(_) => continue,
@@ -294,7 +362,7 @@ pub(super) fn process_schema_composition(
                     state.depth += 1;
                     let ext_validator_res = XsdValidator::from_schema_with_composition_state(
                         &ext_doc,
-                        Some(&canonical_path),
+                        Some(&resolved_schema.path),
                         state,
                     );
                     state.depth -= 1;
@@ -663,4 +731,39 @@ fn is_absolute_uri(s: &str) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn read_resolved_schema_detects_stale_file_identity() {
+        let dir = std::env::temp_dir().join(format!(
+            "uppsala-composition-race-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("include.xsd");
+        fs::write(&path, "old").unwrap();
+        let metadata = fs::metadata(&path).unwrap();
+        let resolved = ResolvedSchemaPath {
+            path: path.clone(),
+            identity: file_identity(&metadata),
+        };
+        let replacement = dir.join("replacement.xsd");
+        fs::write(&replacement, "new").unwrap();
+        fs::rename(&replacement, &path).unwrap();
+
+        let err = read_resolved_schema(&resolved, "include.xsd", "include")
+            .expect_err("changed file identity must be rejected");
+        assert!(err.to_string().contains("file changed during resolution"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/xsd/datetime.rs
+++ b/src/xsd/datetime.rs
@@ -1,15 +1,15 @@
 //! Date/time validation helpers for XSD built-in date and time types.
 //!
 //! Implements format validation for all XSD date/time types:
-//! - `xs:dateTime` (YYYY-MM-DDThh:mm:ss[.sss][timezone])
-//! - `xs:date` (YYYY-MM-DD[timezone])
-//! - `xs:time` (hh:mm:ss[.sss][timezone])
-//! - `xs:duration` (PnYnMnDTnHnMnS)
-//! - `xs:gYear` ([-]CCYY[timezone])
-//! - `xs:gYearMonth` ([-]CCYY-MM[timezone])
-//! - `xs:gMonth` (--MM[timezone])
-//! - `xs:gMonthDay` (--MM-DD[timezone])
-//! - `xs:gDay` (---DD[timezone])
+//! - `xs:dateTime` (`YYYY-MM-DDThh:mm:ss[.sss][timezone]`)
+//! - `xs:date` (`YYYY-MM-DD[timezone]`)
+//! - `xs:time` (`hh:mm:ss[.sss][timezone]`)
+//! - `xs:duration` (`PnYnMnDTnHnMnS`)
+//! - `xs:gYear` (`[-]CCYY[timezone]`)
+//! - `xs:gYearMonth` (`[-]CCYY-MM[timezone]`)
+//! - `xs:gMonth` (`--MM[timezone]`)
+//! - `xs:gMonthDay` (`--MM-DD[timezone]`)
+//! - `xs:gDay` (`---DD[timezone]`)
 //!
 //! Timezone is always optional and can be `Z`, `+hh:mm`, or `-hh:mm`.
 //! Also provides a `normalize_datetime_tz` function for normalizing timezone
@@ -155,7 +155,10 @@ pub(crate) fn is_valid_gyearmonth(s: &str) -> bool {
 /// for backwards compatibility.
 pub(crate) fn is_valid_gmonth(s: &str) -> bool {
     let s = strip_timezone(s);
-    if !s.starts_with("--") || s.len() < 4 {
+    // gMonth is an all-ASCII lexical form. Reject any non-ASCII byte up front so
+    // the fixed byte-index slices below cannot land inside a multibyte UTF-8
+    // sequence and panic on a non-char-boundary.
+    if !s.is_ascii() || !s.starts_with("--") || s.len() < 4 {
         return false;
     }
     let month_str = &s[2..4];
@@ -215,7 +218,9 @@ fn is_leap_year(year: u32) -> bool {
 /// since no year is specified).
 pub(crate) fn is_valid_gmonthday(s: &str) -> bool {
     let s = strip_timezone(s);
-    if !s.starts_with("--") || s.len() < 7 {
+    // All-ASCII lexical form; reject non-ASCII so the byte slices below stay on
+    // char boundaries.
+    if !s.is_ascii() || !s.starts_with("--") || s.len() < 7 {
         return false;
     }
     let month_str = &s[2..4];
@@ -248,7 +253,9 @@ pub(crate) fn is_valid_gmonthday(s: &str) -> bool {
 /// Day must be 01-31.
 pub(crate) fn is_valid_gday(s: &str) -> bool {
     let s = strip_timezone(s);
-    if !s.starts_with("---") || s.len() < 5 {
+    // All-ASCII lexical form; reject non-ASCII so the byte slices below stay on
+    // char boundaries.
+    if !s.is_ascii() || !s.starts_with("---") || s.len() < 5 {
         return false;
     }
     let day_str = &s[3..5];
@@ -308,7 +315,7 @@ pub(crate) fn normalize_datetime_tz(s: &str) -> String {
     val
 }
 
-/// Validate dateTime format: YYYY-MM-DDThh:mm:ss[.sss][Z|(+|-)hh:mm]
+/// Validate dateTime format: `YYYY-MM-DDThh:mm:ss[.sss][Z|(+|-)hh:mm]`
 ///
 /// Splits on 'T' and validates the date part and time part independently.
 pub(crate) fn is_valid_datetime(s: &str) -> bool {
@@ -404,20 +411,29 @@ pub(crate) fn is_valid_date(s: &str) -> bool {
     true
 }
 
-/// Validate time format: hh:mm:ss[.sss][Z|(+|-)hh:mm]
+/// Validate time format: `hh:mm:ss[.sss][Z|(+|-)hh:mm]`
 ///
 /// Hours must be 00-24 (24:00:00 is valid as end-of-day midnight).
 /// Minutes must be 00-59, seconds must be 00-59. Fractional seconds
 /// are allowed. MS tests: time016/017/018 — reject invalid ranges.
 pub(crate) fn is_valid_time(s: &str) -> bool {
     // hh:mm:ss[.sss][Z|(+|-)hh:mm]
-    let s = strip_time_timezone(s);
+    let Some(s) = strip_time_timezone(s) else {
+        return false;
+    };
     let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() < 3 {
+    if parts.len() != 3 {
         return false;
     }
     // Allow seconds with fractional part
     let seconds_parts: Vec<&str> = parts[2].split('.').collect();
+    if seconds_parts.len() > 2
+        || (seconds_parts.len() == 2
+            && (seconds_parts[1].is_empty()
+                || !seconds_parts[1].chars().all(|c| c.is_ascii_digit())))
+    {
+        return false;
+    }
     if parts[0].len() != 2
         || parts[1].len() != 2
         || seconds_parts[0].len() != 2
@@ -441,28 +457,35 @@ pub(crate) fn is_valid_time(s: &str) -> bool {
     };
     // 24:00:00 is allowed as midnight end-of-day, but nothing else with hour=24
     if hours == 24 {
-        return minutes == 0 && seconds == 0;
+        let fractional_zero = seconds_parts
+            .get(1)
+            .is_none_or(|fraction| fraction.chars().all(|c| c == '0'));
+        return minutes == 0 && seconds == 0 && fractional_zero;
     }
     hours <= 23 && minutes <= 59 && seconds <= 59
 }
 
-/// Strip timezone from a time-only string (hh:mm:ss[.sss][Z|(+|-)hh:mm]).
+/// Strip timezone from a time-only string (`hh:mm:ss[.sss][Z|(+|-)hh:mm]`).
 ///
-/// Returns the time string without any timezone suffix.
-fn strip_time_timezone(s: &str) -> &str {
+/// Returns the time string without any timezone suffix, or `None` if a suffix
+/// is present but malformed.
+fn strip_time_timezone(s: &str) -> Option<&str> {
     if let Some(stripped) = s.strip_suffix('Z') {
-        return stripped;
+        return Some(stripped);
     }
     // Look for timezone offset: +hh:mm or -hh:mm at the end
     // A timezone offset has the form [+-]dd:dd at the end (6 chars)
     if s.len() >= 6 {
         let tz_start = s.len() - 6;
-        let c = s.as_bytes()[tz_start];
-        if (c == b'+' || c == b'-') && s.as_bytes()[tz_start + 3] == b':' {
-            return &s[..tz_start];
+        let tz = &s.as_bytes()[tz_start..];
+        if tz[0] == b'+' || tz[0] == b'-' {
+            if !s.is_char_boundary(tz_start) || !valid_timezone_offset_bytes(tz) {
+                return None;
+            }
+            return Some(&s[..tz_start]);
         }
     }
-    s
+    Some(s)
 }
 
 /// Strip timezone suffix from date strings.
@@ -489,4 +512,28 @@ pub(crate) fn strip_timezone(s: &str) -> &str {
         }
     }
     s
+}
+
+fn valid_timezone_offset_bytes(tz: &[u8]) -> bool {
+    if tz.len() != 6 || !(tz[0] == b'+' || tz[0] == b'-') || tz[3] != b':' {
+        return false;
+    }
+
+    let hour = match two_digit_value(tz[1], tz[2]) {
+        Some(value) => value,
+        None => return false,
+    };
+    let minute = match two_digit_value(tz[4], tz[5]) {
+        Some(value) => value,
+        None => return false,
+    };
+
+    hour < 14 && minute <= 59 || hour == 14 && minute == 0
+}
+
+fn two_digit_value(tens: u8, ones: u8) -> Option<u32> {
+    if !tens.is_ascii_digit() || !ones.is_ascii_digit() {
+        return None;
+    }
+    Some(((tens - b'0') as u32) * 10 + (ones - b'0') as u32)
 }

--- a/src/xsd/datetime.rs
+++ b/src/xsd/datetime.rs
@@ -107,7 +107,9 @@ pub(crate) fn is_valid_duration(s: &str) -> bool {
 /// The year must be at least 4 digits (CCYY). Leading '-' for negative years
 /// (BCE dates) is permitted. Timezone suffix is optional.
 pub(crate) fn is_valid_gyear(s: &str) -> bool {
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     let s = if let Some(stripped) = s.strip_prefix('-') {
         stripped
     } else {
@@ -120,7 +122,9 @@ pub(crate) fn is_valid_gyear(s: &str) -> bool {
 ///
 /// Year must be at least 4 digits, month must be 01-12.
 pub(crate) fn is_valid_gyearmonth(s: &str) -> bool {
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     let (s, _neg) = if let Some(stripped) = s.strip_prefix('-') {
         (stripped, true)
     } else {
@@ -154,7 +158,9 @@ pub(crate) fn is_valid_gyearmonth(s: &str) -> bool {
 /// Note: XSD 1.0 also allowed --MM-- (with trailing --), so we accept both
 /// for backwards compatibility.
 pub(crate) fn is_valid_gmonth(s: &str) -> bool {
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     // gMonth is an all-ASCII lexical form. Reject any non-ASCII byte up front so
     // the fixed byte-index slices below cannot land inside a multibyte UTF-8
     // sequence and panic on a non-char-boundary.
@@ -217,7 +223,9 @@ fn is_leap_year(year: u32) -> bool {
 /// Month must be 01-12, day must be valid for that month (Feb allows up to 29
 /// since no year is specified).
 pub(crate) fn is_valid_gmonthday(s: &str) -> bool {
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     // All-ASCII lexical form; reject non-ASCII so the byte slices below stay on
     // char boundaries.
     if !s.is_ascii() || !s.starts_with("--") || s.len() < 7 {
@@ -252,7 +260,9 @@ pub(crate) fn is_valid_gmonthday(s: &str) -> bool {
 ///
 /// Day must be 01-31.
 pub(crate) fn is_valid_gday(s: &str) -> bool {
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     // All-ASCII lexical form; reject non-ASCII so the byte slices below stay on
     // char boundaries.
     if !s.is_ascii() || !s.starts_with("---") || s.len() < 5 {
@@ -336,7 +346,9 @@ pub(crate) fn is_valid_datetime(s: &str) -> bool {
 /// MS tests: date003/004/009, dateTime011 — reject invalid ranges.
 pub(crate) fn is_valid_date(s: &str) -> bool {
     // YYYY-MM-DD[Z|(+|-)hh:mm]
-    let s = strip_timezone(s);
+    let Some(s) = strip_timezone(s) else {
+        return false;
+    };
     let parts: Vec<&str> = s.split('-').collect();
     // Handle negative years
     if s.starts_with('-') {
@@ -478,7 +490,13 @@ fn strip_time_timezone(s: &str) -> Option<&str> {
     if s.len() >= 6 {
         let tz_start = s.len() - 6;
         let tz = &s.as_bytes()[tz_start..];
-        if tz[0] == b'+' || tz[0] == b'-' {
+        if (tz[0] == b'+' || tz[0] == b'-')
+            && tz[1].is_ascii_digit()
+            && tz[2].is_ascii_digit()
+            && tz[3] == b':'
+            && tz[4].is_ascii_digit()
+            && tz[5].is_ascii_digit()
+        {
             if !s.is_char_boundary(tz_start) || !valid_timezone_offset_bytes(tz) {
                 return None;
             }
@@ -493,25 +511,28 @@ fn strip_time_timezone(s: &str) -> Option<&str> {
 /// Timezone is Z, +hh:mm, or -hh:mm at the end.
 /// MS tests: gYearMonth003, gYear006, gMonthDay003, gDay003, gMonth004 —
 /// the old `pos > 8` heuristic failed for short types like gYear, gDay.
-pub(crate) fn strip_timezone(s: &str) -> &str {
+pub(crate) fn strip_timezone(s: &str) -> Option<&str> {
     if let Some(stripped) = s.strip_suffix('Z') {
-        return stripped;
+        return Some(stripped);
     }
     // Check for +hh:mm or -hh:mm at the end (exactly 6 chars: [+-]dd:dd)
     if s.len() >= 6 {
         let tz_start = s.len() - 6;
-        let b = s.as_bytes();
-        if (b[tz_start] == b'+' || b[tz_start] == b'-')
-            && b[tz_start + 1].is_ascii_digit()
-            && b[tz_start + 2].is_ascii_digit()
-            && b[tz_start + 3] == b':'
-            && b[tz_start + 4].is_ascii_digit()
-            && b[tz_start + 5].is_ascii_digit()
+        let tz = &s.as_bytes()[tz_start..];
+        if (tz[0] == b'+' || tz[0] == b'-')
+            && tz[1].is_ascii_digit()
+            && tz[2].is_ascii_digit()
+            && tz[3] == b':'
+            && tz[4].is_ascii_digit()
+            && tz[5].is_ascii_digit()
         {
-            return &s[..tz_start];
+            if !s.is_char_boundary(tz_start) || !valid_timezone_offset_bytes(tz) {
+                return None;
+            }
+            return Some(&s[..tz_start]);
         }
     }
-    s
+    Some(s)
 }
 
 fn valid_timezone_offset_bytes(tz: &[u8]) -> bool {

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -31,7 +31,12 @@ impl XsdValidator {
                 continue; // Process keyrefs in second pass
             }
 
-            let selected = idc_select_nodes(doc, context_node, &constraint.selector);
+            let selected = idc_select_nodes(
+                doc,
+                context_node,
+                &constraint.selector,
+                &constraint.namespaces,
+            );
             debug_log!(
                 "identity constraint '{}' ({:?}): selector='{}' selected {} nodes",
                 constraint.name,
@@ -50,7 +55,7 @@ impl XsdValidator {
 
                 for field_xpath in &constraint.fields {
                     let (value, match_count, source_node) =
-                        idc_evaluate_field(doc, sel_node, field_xpath);
+                        idc_evaluate_field(doc, sel_node, field_xpath, &constraint.namespaces);
                     // For xs:key (and xs:unique), if a field selects more than one node,
                     // that's an error per XSD spec §3.11.4
                     if match_count > 1 && constraint.kind == IdentityConstraintKind::Key {
@@ -172,7 +177,12 @@ impl XsdValidator {
             }
             let referred_tuples = referred_tuples.unwrap();
 
-            let selected = idc_select_nodes(doc, context_node, &constraint.selector);
+            let selected = idc_select_nodes(
+                doc,
+                context_node,
+                &constraint.selector,
+                &constraint.namespaces,
+            );
             debug_log!(
                 "keyref '{}': selector='{}' selected {} nodes, referred key '{}' has {} tuples",
                 constraint.name,
@@ -189,7 +199,7 @@ impl XsdValidator {
 
                 for field_xpath in &constraint.fields {
                     let (value, _match_count, source_node) =
-                        idc_evaluate_field(doc, sel_node, field_xpath);
+                        idc_evaluate_field(doc, sel_node, field_xpath, &constraint.namespaces);
                     if value.is_none() {
                         all_present = false;
                     }
@@ -246,7 +256,12 @@ impl XsdValidator {
 ///   path     ::= ('.//') ? step ('/' step)*
 ///   step     ::= '.' | nametest
 ///   nametest ::= qname | '*'
-fn idc_select_nodes(doc: &Document, context: NodeId, selector: &str) -> Vec<NodeId> {
+fn idc_select_nodes(
+    doc: &Document,
+    context: NodeId,
+    selector: &str,
+    namespaces: &HashMap<String, String>,
+) -> Vec<NodeId> {
     let mut results = Vec::new();
 
     // Split on '|' for union
@@ -263,7 +278,9 @@ fn idc_select_nodes(doc: &Document, context: NodeId, selector: &str) -> Vec<Node
             let mut descendants = Vec::new();
             idc_collect_descendants(doc, context, &mut descendants);
             for desc in descendants {
-                if idc_match_steps(doc, context, desc, &steps, 0) && !results.contains(&desc) {
+                if idc_match_steps(doc, context, desc, &steps, namespaces)
+                    && !results.contains(&desc)
+                {
                     results.push(desc);
                 }
             }
@@ -275,7 +292,7 @@ fn idc_select_nodes(doc: &Document, context: NodeId, selector: &str) -> Vec<Node
                 for &cand in &candidates {
                     for child in doc.children(cand) {
                         if let Some(NodeKind::Element(_)) = doc.node_kind(child) {
-                            if idc_step_matches(doc, child, step) {
+                            if idc_step_matches(doc, child, step, namespaces) {
                                 if i == steps.len() - 1 {
                                     if !results.contains(&child) {
                                         results.push(child);
@@ -317,7 +334,12 @@ fn idc_parse_path(path: &str) -> (bool, Vec<String>) {
 }
 
 /// Check if a node matches a single step (name test or wildcard).
-fn idc_step_matches(doc: &Document, node: NodeId, step: &str) -> bool {
+fn idc_step_matches(
+    doc: &Document,
+    node: NodeId,
+    step: &str,
+    namespaces: &HashMap<String, String>,
+) -> bool {
     if step == "*" {
         // Wildcard matches any element
         return doc.element(node).is_some();
@@ -329,17 +351,14 @@ fn idc_step_matches(doc: &Document, node: NodeId, step: &str) -> bool {
     if let Some(elem) = doc.element(node) {
         // Check name match. The step might have a namespace prefix.
         if let Some(colon) = step.find(':') {
-            let _prefix = &step[..colon];
+            let prefix = &step[..colon];
             let local = &step[colon + 1..];
-            // For namespace-qualified steps, compare local name and check that
-            // the element has a namespace matching the prefix's namespace.
-            // In XSD identity constraints, the prefix is resolved from the schema document's
-            // namespace bindings, which typically match the instance document's target namespace.
-            elem.name.local_name == local
+            namespaces.get(prefix).is_some_and(|expected_ns| {
+                elem.name.local_name == local
+                    && elem.name.namespace_uri.as_deref() == Some(expected_ns.as_str())
+            })
         } else {
-            // Unprefixed: match local name, typically for elements in a namespace
-            // (the schema's target namespace)
-            elem.name.local_name == step
+            elem.name.local_name == step && elem.name.namespace_uri.is_none()
         }
     } else {
         false
@@ -367,7 +386,7 @@ fn idc_match_steps(
     context: NodeId,
     target: NodeId,
     steps: &[String],
-    _step_idx: usize,
+    namespaces: &HashMap<String, String>,
 ) -> bool {
     if steps.is_empty() {
         return false;
@@ -395,7 +414,7 @@ fn idc_match_steps(
     // `.//v:state/v:vehicle` to match a vehicle whose immediate parent is a state.
     let offset = path_to_target.len() - steps.len();
     for (i, step) in steps.iter().enumerate() {
-        if !idc_step_matches(doc, path_to_target[offset + i], step) {
+        if !idc_step_matches(doc, path_to_target[offset + i], step, namespaces) {
             return false;
         }
     }
@@ -419,6 +438,7 @@ fn idc_evaluate_field(
     doc: &Document,
     node: NodeId,
     field: &str,
+    namespaces: &HashMap<String, String>,
 ) -> (Option<String>, usize, Option<NodeId>) {
     let field = field.trim();
 
@@ -445,7 +465,7 @@ fn idc_evaluate_field(
             let mut count = 0;
             let mut value = None;
             for attr in &elem.attributes {
-                if attr.name.local_name == attr_name {
+                if idc_attr_matches(&attr.name, attr_name, namespaces) {
                     count += 1;
                     if value.is_none() {
                         value = Some(attr.value.to_string());
@@ -470,7 +490,7 @@ fn idc_evaluate_field(
         for &cn in &current_nodes {
             for child in doc.children(cn) {
                 if let Some(NodeKind::Element(_)) = doc.node_kind(child) {
-                    if idc_step_matches(doc, child, part) {
+                    if idc_step_matches(doc, child, part, namespaces) {
                         next_nodes.push(child);
                     }
                 }
@@ -497,6 +517,22 @@ fn idc_evaluate_field(
         (Some(trimmed.to_string()), match_count, Some(result_node))
     } else {
         (None, 0, None)
+    }
+}
+
+fn idc_attr_matches(
+    name: &crate::dom::QName<'_>,
+    test: &str,
+    namespaces: &HashMap<String, String>,
+) -> bool {
+    if let Some(colon) = test.find(':') {
+        let prefix = &test[..colon];
+        let local = &test[colon + 1..];
+        namespaces.get(prefix).is_some_and(|expected_ns| {
+            name.local_name == local && name.namespace_uri.as_deref() == Some(expected_ns.as_str())
+        })
+    } else {
+        name.local_name == test && name.namespace_uri.is_none()
     }
 }
 

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -375,10 +375,15 @@ fn idc_step_matches(
 
 /// Collect all descendant element nodes.
 fn idc_collect_descendants(doc: &Document, node: NodeId, result: &mut Vec<NodeId>) {
-    for child in doc.children(node) {
-        if let Some(NodeKind::Element(_)) = doc.node_kind(child) {
-            result.push(child);
-            idc_collect_descendants(doc, child, result);
+    let mut stack = doc.children(node);
+    stack.reverse();
+
+    while let Some(current) = stack.pop() {
+        if let Some(NodeKind::Element(_)) = doc.node_kind(current) {
+            result.push(current);
+            let mut children = doc.children(current);
+            children.reverse();
+            stack.extend(children);
         }
     }
 }

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -35,7 +35,7 @@ impl XsdValidator {
                 doc,
                 context_node,
                 &constraint.selector,
-                &constraint.namespaces,
+                &constraint.selector_namespaces,
             );
             debug_log!(
                 "identity constraint '{}' ({:?}): selector='{}' selected {} nodes",
@@ -53,9 +53,13 @@ impl XsdValidator {
                 let mut all_present = true;
                 let mut multiplicity_error = false;
 
-                for field_xpath in &constraint.fields {
+                for (field_index, field_xpath) in constraint.fields.iter().enumerate() {
+                    let field_namespaces = constraint
+                        .field_namespaces
+                        .get(field_index)
+                        .unwrap_or(&constraint.namespaces);
                     let (value, match_count, source_node) =
-                        idc_evaluate_field(doc, sel_node, field_xpath, &constraint.namespaces);
+                        idc_evaluate_field(doc, sel_node, field_xpath, field_namespaces);
                     // For xs:key (and xs:unique), if a field selects more than one node,
                     // that's an error per XSD spec §3.11.4
                     if match_count > 1 && constraint.kind == IdentityConstraintKind::Key {
@@ -181,7 +185,7 @@ impl XsdValidator {
                 doc,
                 context_node,
                 &constraint.selector,
-                &constraint.namespaces,
+                &constraint.selector_namespaces,
             );
             debug_log!(
                 "keyref '{}': selector='{}' selected {} nodes, referred key '{}' has {} tuples",
@@ -197,9 +201,13 @@ impl XsdValidator {
                 let mut field_source_nodes: Vec<Option<NodeId>> = Vec::new();
                 let mut all_present = true;
 
-                for field_xpath in &constraint.fields {
+                for (field_index, field_xpath) in constraint.fields.iter().enumerate() {
+                    let field_namespaces = constraint
+                        .field_namespaces
+                        .get(field_index)
+                        .unwrap_or(&constraint.namespaces);
                     let (value, _match_count, source_node) =
-                        idc_evaluate_field(doc, sel_node, field_xpath, &constraint.namespaces);
+                        idc_evaluate_field(doc, sel_node, field_xpath, field_namespaces);
                     if value.is_none() {
                         all_present = false;
                     }

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -5,7 +5,7 @@
 //! `.//` descendant selectors, composite (multi-field) keys, QName
 //! namespace-aware value comparison, and decimal normalization.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::ValidationError;
@@ -271,6 +271,11 @@ fn idc_select_nodes(
     namespaces: &HashMap<String, String>,
 ) -> Vec<NodeId> {
     let mut results = Vec::new();
+    // Track membership in O(1) instead of an O(n) `results.contains()` scan per
+    // candidate; for broad selectors (e.g. `.//*` or wide unions) the linear
+    // scan made selection O(n^2), a schema-driven DoS during validation. The
+    // set only gates pushes, so `results` keeps its deterministic order.
+    let mut seen: HashSet<NodeId> = HashSet::new();
 
     // Split on '|' for union
     for path_str in selector.split('|') {
@@ -286,9 +291,7 @@ fn idc_select_nodes(
             let mut descendants = Vec::new();
             idc_collect_descendants(doc, context, &mut descendants);
             for desc in descendants {
-                if idc_match_steps(doc, context, desc, &steps, namespaces)
-                    && !results.contains(&desc)
-                {
+                if idc_match_steps(doc, context, desc, &steps, namespaces) && seen.insert(desc) {
                     results.push(desc);
                 }
             }
@@ -302,7 +305,7 @@ fn idc_select_nodes(
                         if let Some(NodeKind::Element(_)) = doc.node_kind(child) {
                             if idc_step_matches(doc, child, step, namespaces) {
                                 if i == steps.len() - 1 {
-                                    if !results.contains(&child) {
+                                    if seen.insert(child) {
                                         results.push(child);
                                     }
                                 } else {

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -103,7 +103,7 @@ pub(super) fn parse_element_decl(
     };
 
     let type_ref = if let Some(type_name) = elem.get_attribute("type") {
-        resolve_type_name(type_name, schema_target_ns)
+        resolve_type_name(doc, node, type_name, schema_target_ns)?
     } else {
         // Check for inline type definition
         let mut inline_type = TypeRef::BuiltIn(BuiltInType::AnyType);
@@ -211,17 +211,29 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                     kind, name, selector, fields, refer
                 );
 
+                let namespaces = identity_constraint_namespaces(doc, child);
+
                 constraints.push(IdentityConstraint {
                     name,
                     kind,
                     selector,
                     fields,
                     refer,
+                    namespaces,
                 });
             }
         }
     }
     constraints
+}
+
+fn identity_constraint_namespaces(doc: &Document, node: NodeId) -> HashMap<String, String> {
+    build_resolver_for_node(doc, node)
+        .in_scope_namespaces()
+        .into_iter()
+        .filter(|(prefix, _)| !prefix.is_empty())
+        .map(|(prefix, uri)| (prefix.to_string(), uri.to_string()))
+        .collect()
 }
 
 /// Parse the `substitutionGroup` attribute from an element declaration.
@@ -259,7 +271,12 @@ fn parse_substitution_group(
 ///
 /// If the name matches a built-in XSD type, returns `TypeRef::BuiltIn`.
 /// Otherwise returns `TypeRef::Named` with the appropriate namespace.
-pub(super) fn resolve_type_name(type_name: &str, target_ns: &Option<String>) -> TypeRef {
+pub(super) fn resolve_type_name(
+    doc: &Document,
+    node: NodeId,
+    type_name: &str,
+    target_ns: &Option<String>,
+) -> XmlResult<TypeRef> {
     // Check for xs: prefix
     let (prefix, local) = if let Some(colon) = type_name.find(':') {
         (&type_name[..colon], &type_name[colon + 1..])
@@ -271,7 +288,7 @@ pub(super) fn resolve_type_name(type_name: &str, target_ns: &Option<String>) -> 
 
     if is_builtin {
         if let Some(bt) = parse_builtin_type(local) {
-            return TypeRef::BuiltIn(bt);
+            return Ok(TypeRef::BuiltIn(bt));
         }
     }
 
@@ -280,19 +297,32 @@ pub(super) fn resolve_type_name(type_name: &str, target_ns: &Option<String>) -> 
     // (e.g., xmlns="http://www.w3.org/2001/XMLSchema").
     if prefix.is_empty() {
         if let Some(bt) = parse_builtin_type(local) {
-            return TypeRef::BuiltIn(bt);
+            return Ok(TypeRef::BuiltIn(bt));
         }
     }
 
     // Named type reference
     if is_builtin {
-        TypeRef::Named(Some(XS_NAMESPACE.to_string()), local.to_string())
+        Ok(TypeRef::Named(
+            Some(XS_NAMESPACE.to_string()),
+            local.to_string(),
+        ))
     } else if prefix.is_empty() {
-        TypeRef::Named(target_ns.clone(), local.to_string())
+        Ok(TypeRef::Named(target_ns.clone(), local.to_string()))
     } else {
-        // Non-builtin prefixed type — assume it's in the target namespace
-        // (In a full implementation we'd resolve the prefix via namespace declarations)
-        TypeRef::Named(target_ns.clone(), local.to_string())
+        let resolver = build_resolver_for_node(doc, node);
+        let ns_uri = resolver.resolve(prefix).ok_or_else(|| {
+            XmlError::validation(format!(
+                "Undeclared namespace prefix '{}' in type QName '{}'",
+                prefix, type_name
+            ))
+        })?;
+        if ns_uri.as_ref() == XS_NAMESPACE {
+            if let Some(bt) = parse_builtin_type(local) {
+                return Ok(TypeRef::BuiltIn(bt));
+            }
+        }
+        Ok(TypeRef::Named(Some(ns_uri.to_string()), local.to_string()))
     }
 }
 
@@ -538,7 +568,12 @@ pub(super) fn parse_complex_type(
                                     if let Some(base) = gc_elem.get_attribute("base") {
                                         // Track base type for block checking
                                         // Type references always resolve against the schema target namespace
-                                        let base_ref = resolve_type_name(base, schema_target_ns);
+                                        let base_ref = resolve_type_name(
+                                            doc,
+                                            grandchild,
+                                            base,
+                                            schema_target_ns,
+                                        )?;
                                         if let TypeRef::Named(ns, ln) = &base_ref {
                                             base_type = Some((ns.clone(), ln.clone()));
                                         }
@@ -1161,7 +1196,7 @@ fn parse_attribute_decl(doc: &Document, node: NodeId) -> XmlResult<AttributeDecl
     };
 
     let type_ref = if let Some(type_name) = elem.get_attribute("type") {
-        resolve_type_name(type_name, &None)
+        resolve_type_name(doc, node, type_name, &None)?
     } else {
         // Check for inline simpleType child
         let mut found_inline = None;

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -181,7 +181,9 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                 });
 
                 let mut selector = String::new();
+                let mut selector_namespaces = None;
                 let mut fields = Vec::new();
+                let mut field_namespaces = Vec::new();
 
                 for gc in doc.children(child) {
                     if let Some(NodeKind::Element(gc_elem)) = doc.node_kind(gc) {
@@ -195,10 +197,13 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                             match gc_elem.name.local_name.as_ref() {
                                 "selector" => {
                                     selector = gce.get_attribute("xpath").unwrap_or("").to_string();
+                                    selector_namespaces =
+                                        Some(identity_constraint_namespaces(doc, gc));
                                 }
                                 "field" => {
                                     fields
                                         .push(gce.get_attribute("xpath").unwrap_or("").to_string());
+                                    field_namespaces.push(identity_constraint_namespaces(doc, gc));
                                 }
                                 _ => {}
                             }
@@ -212,6 +217,7 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                 );
 
                 let namespaces = identity_constraint_namespaces(doc, child);
+                let selector_namespaces = selector_namespaces.unwrap_or_else(|| namespaces.clone());
 
                 constraints.push(IdentityConstraint {
                     name,
@@ -220,6 +226,8 @@ fn parse_identity_constraints(doc: &Document, elem_node: NodeId) -> Vec<Identity
                     fields,
                     refer,
                     namespaces,
+                    selector_namespaces,
+                    field_namespaces,
                 });
             }
         }

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -104,6 +104,8 @@ pub(crate) struct IdentityConstraint {
     pub(super) fields: Vec<String>,
     /// For keyref: the name of the referred key/unique constraint.
     pub(super) refer: Option<String>,
+    /// Prefix bindings used by selector and field XPath expressions.
+    pub(super) namespaces: HashMap<String, String>,
 }
 
 /// The kind of identity constraint.
@@ -148,6 +150,10 @@ pub(crate) enum NamespaceConstraint {
     TargetNamespace(Option<String>), // holds the target namespace
     /// Explicit list of namespace URIs
     List(Vec<String>),
+    /// Any namespace-qualified name, but not no-namespace names.
+    NotLocal,
+    /// Any namespace-qualified name except the listed namespace URIs.
+    Not(Vec<String>),
 }
 
 /// processContents for wildcards.
@@ -202,6 +208,10 @@ impl AttributeWildcard {
                 None => uris.iter().any(|u| u == "##local"),
                 Some(ns) => uris.iter().any(|u| u == ns),
             },
+            NamespaceConstraint::NotLocal => attr_ns.is_some(),
+            NamespaceConstraint::Not(excluded) => {
+                matches!(attr_ns, Some(ns) if !excluded.iter().any(|u| u == ns))
+            }
         }
     }
 

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -104,8 +104,12 @@ pub(crate) struct IdentityConstraint {
     pub(super) fields: Vec<String>,
     /// For keyref: the name of the referred key/unique constraint.
     pub(super) refer: Option<String>,
-    /// Prefix bindings used by selector and field XPath expressions.
+    /// Prefix bindings declared on the constraint element.
     pub(super) namespaces: HashMap<String, String>,
+    /// Prefix bindings visible from the selector XPath expression.
+    pub(super) selector_namespaces: HashMap<String, String>,
+    /// Prefix bindings visible from each field XPath expression.
+    pub(super) field_namespaces: Vec<HashMap<String, String>>,
 }
 
 /// The kind of identity constraint.

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -158,6 +158,8 @@ pub(crate) enum NamespaceConstraint {
     NotLocal,
     /// Any namespace-qualified name except the listed namespace URIs.
     Not(Vec<String>),
+    /// Any namespace, including no namespace, except the listed namespace URIs.
+    AnyExcept(Vec<String>),
 }
 
 /// processContents for wildcards.
@@ -216,6 +218,10 @@ impl AttributeWildcard {
             NamespaceConstraint::Not(excluded) => {
                 matches!(attr_ns, Some(ns) if !excluded.iter().any(|u| u == ns))
             }
+            NamespaceConstraint::AnyExcept(excluded) => match attr_ns {
+                None => true,
+                Some(ns) => !excluded.iter().any(|u| u == ns),
+            },
         }
     }
 

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -10,6 +10,8 @@
 //! - xsi:type resolution and type substitution blocking checks
 //! - Substitution group matching for element declarations
 
+use std::collections::HashSet;
+
 use crate::dom::{Document, NodeId, NodeKind};
 use crate::error::ValidationError;
 use crate::namespace::build_resolver_for_node;
@@ -71,10 +73,13 @@ impl XsdValidator {
         );
         let key_no_ns = (None, elem.name.local_name.to_string());
 
-        let decl = self
-            .elements
-            .get(&key_with_ns)
-            .or_else(|| self.elements.get(&key_no_ns));
+        let decl = self.elements.get(&key_with_ns).or_else(|| {
+            if elem.name.namespace_uri.is_none() {
+                self.elements.get(&key_no_ns)
+            } else {
+                None
+            }
+        });
 
         match decl {
             Some(decl) => {
@@ -244,6 +249,7 @@ impl XsdValidator {
         let mut has_extension_in_chain = false;
         let mut has_restriction_in_chain = false;
         let mut current = xsi_type;
+        let mut seen = HashSet::new();
 
         while let TypeDef::Complex(ct) = current {
             let is_extension = match ct.derived_by_extension {
@@ -284,6 +290,12 @@ impl XsdValidator {
 
             // Move up to base type
             if let Some(ref base_key) = ct.base_type {
+                if !seen.insert(base_key.clone()) {
+                    return Some(format!(
+                        "Type derivation cycle detected involving '{}'",
+                        base_key.1
+                    ));
+                }
                 if let Some(base_td) = self.types.get(base_key) {
                     current = base_td;
                 } else {
@@ -422,11 +434,22 @@ impl XsdValidator {
     /// effective wildcard and the derived type's own wildcard.
     /// For restriction types or types not derived, this is just the type's own wildcard.
     fn compute_effective_wildcard(&self, ct: &ComplexTypeDef) -> Option<AttributeWildcard> {
+        self.compute_effective_wildcard_inner(ct, &mut HashSet::new())
+    }
+
+    fn compute_effective_wildcard_inner(
+        &self,
+        ct: &ComplexTypeDef,
+        seen: &mut HashSet<(Option<String>, String)>,
+    ) -> Option<AttributeWildcard> {
         if ct.derived_by_extension == Some(true) {
             // Get the base type's effective wildcard (recursively)
             let base_wildcard = if let Some(ref base_key) = ct.base_type {
+                if !seen.insert(base_key.clone()) {
+                    return None;
+                }
                 if let Some(TypeDef::Complex(base_ct)) = self.types.get(base_key) {
-                    self.compute_effective_wildcard(base_ct)
+                    self.compute_effective_wildcard_inner(base_ct, seen)
                 } else {
                     None
                 }
@@ -455,10 +478,21 @@ impl XsdValidator {
     ///   the restriction are inherited; prohibited attributes are removed
     /// - **Not derived**: just the type's own attributes
     fn compute_effective_attributes(&self, ct: &ComplexTypeDef) -> Vec<AttributeDecl> {
+        self.compute_effective_attributes_inner(ct, &mut HashSet::new())
+    }
+
+    fn compute_effective_attributes_inner(
+        &self,
+        ct: &ComplexTypeDef,
+        seen: &mut HashSet<(Option<String>, String)>,
+    ) -> Vec<AttributeDecl> {
         // Get base type's effective attributes
         let base_attrs = if let Some(ref base_key) = ct.base_type {
+            if !seen.insert(base_key.clone()) {
+                return Vec::new();
+            }
             if let Some(TypeDef::Complex(base_ct)) = self.types.get(base_key) {
-                self.compute_effective_attributes(base_ct)
+                self.compute_effective_attributes_inner(base_ct, seen)
             } else {
                 Vec::new()
             }
@@ -525,25 +559,36 @@ impl XsdValidator {
     ///
     /// Returns `None` if the type is not an extension or cannot be merged.
     fn compute_effective_particles(&self, ct: &ComplexTypeDef) -> Option<Vec<Particle>> {
+        self.compute_effective_particles_inner(ct, &mut HashSet::new())
+    }
+
+    fn compute_effective_particles_inner(
+        &self,
+        ct: &ComplexTypeDef,
+        seen: &mut HashSet<(Option<String>, String)>,
+    ) -> Option<Vec<Particle>> {
         if ct.derived_by_extension != Some(true) {
             return None;
         }
         let (base_ns, base_name) = ct.base_type.as_ref()?;
         let key = (base_ns.clone(), base_name.clone());
+        if !seen.insert(key.clone()) {
+            return None;
+        }
         let base_type = self.types.get(&key)?;
         if let TypeDef::Complex(base_ct) = base_type {
             // Recursively get the base type's effective particles
-            let base_particles = if let Some(recursive) = self.compute_effective_particles(base_ct)
-            {
-                recursive
-            } else {
-                // No further merging needed, just get the base type's own particles
-                match &base_ct.content {
-                    ContentModel::Sequence(particles, _, _) => particles.clone(),
-                    ContentModel::Empty => Vec::new(),
-                    _ => return None, // Can't merge non-sequence base content
-                }
-            };
+            let base_particles =
+                if let Some(recursive) = self.compute_effective_particles_inner(base_ct, seen) {
+                    recursive
+                } else {
+                    // No further merging needed, just get the base type's own particles
+                    match &base_ct.content {
+                        ContentModel::Sequence(particles, _, _) => particles.clone(),
+                        ContentModel::Empty => Vec::new(),
+                        _ => return None, // Can't merge non-sequence base content
+                    }
+                };
 
             // Get the extension's own particles
             let ext_particles = match &ct.content {
@@ -559,6 +604,23 @@ impl XsdValidator {
         } else {
             None
         }
+    }
+
+    fn has_complex_derivation_cycle(&self, ct: &ComplexTypeDef) -> bool {
+        let mut seen = HashSet::new();
+        let mut current = ct;
+
+        while let Some(base_key) = &current.base_type {
+            if !seen.insert(base_key.clone()) {
+                return true;
+            }
+            match self.types.get(base_key) {
+                Some(TypeDef::Complex(base_ct)) => current = base_ct,
+                _ => return false,
+            }
+        }
+
+        false
     }
 
     /// Validate a single element against its element declaration.
@@ -772,8 +834,8 @@ impl XsdValidator {
             }
             None => {
                 // If type can't be resolved, check if it's a built-in
-                if let TypeRef::BuiltIn(bt) = &decl.type_ref {
-                    match bt {
+                match &decl.type_ref {
+                    TypeRef::BuiltIn(bt) => match bt {
                         BuiltInType::AnyType => {
                             // AnyType allows any content, but we should still
                             // validate child elements against their own declarations.
@@ -787,20 +849,31 @@ impl XsdValidator {
                                     .map(|e| &*e.name.local_name)
                                     .unwrap_or("?");
                                 errors.push(ValidationError {
-                                    message: format!(
-                                        "Element '{}' has simple type '{:?}' but contains child elements",
-                                        elem_name, bt
-                                    ),
-                                    line: Some(doc.node_line(node)),
-                                    column: Some(doc.node_column(node)),
-                                });
+                                message: format!(
+                                    "Element '{}' has simple type '{:?}' but contains child elements",
+                                    elem_name, bt
+                                ),
+                                line: Some(doc.node_line(node)),
+                                column: Some(doc.node_column(node)),
+                            });
                             }
                             let text = doc.text_content_deep(node);
                             validate_builtin_value(&text, bt, doc, node, errors);
                         }
+                    },
+                    TypeRef::Named(ns, name) => {
+                        let display = ns
+                            .as_ref()
+                            .map(|uri| format!("{{{}}}{}", uri, name))
+                            .unwrap_or_else(|| name.clone());
+                        errors.push(ValidationError {
+                            message: format!("Type '{}' not found", display),
+                            line: Some(doc.node_line(node)),
+                            column: Some(doc.node_column(node)),
+                        });
                     }
+                    TypeRef::Inline(_) => {}
                 }
-                // Otherwise, no validation possible (unknown type)
             }
         }
 
@@ -866,10 +939,13 @@ impl XsdValidator {
                 );
                 let key_no_ns = (None, child_elem.name.local_name.to_string());
 
-                let child_decl = self
-                    .elements
-                    .get(&key_with_ns)
-                    .or_else(|| self.elements.get(&key_no_ns));
+                let child_decl = self.elements.get(&key_with_ns).or_else(|| {
+                    if child_elem.name.namespace_uri.is_none() {
+                        self.elements.get(&key_no_ns)
+                    } else {
+                        None
+                    }
+                });
 
                 if let Some(decl) = child_decl {
                     self.validate_element(doc, child, decl, errors);
@@ -899,6 +975,15 @@ impl XsdValidator {
         ct: &ComplexTypeDef,
         errors: &mut Vec<ValidationError>,
     ) {
+        if self.has_complex_derivation_cycle(ct) {
+            errors.push(ValidationError {
+                message: "Complex type derivation cycle detected".to_string(),
+                line: Some(doc.node_line(node)),
+                column: Some(doc.node_column(node)),
+            });
+            return;
+        }
+
         // Compute effective attributes (including inherited from base types)
         let effective_attrs = self.compute_effective_attributes(ct);
 
@@ -1846,43 +1931,42 @@ impl XsdValidator {
                         ParticleKind::Any {
                             namespace_constraint,
                             process_contents,
-                        } => {
-                            if wildcard_allows_namespace(
-                                namespace_constraint,
-                                elem.name.namespace_uri.as_deref(),
-                            ) {
-                                matched[i] = true;
-                                match process_contents {
-                                    ProcessContents::Skip => {}
-                                    ProcessContents::Lax => {
-                                        if let Some(global_decl) = self.find_global_element(
-                                            &elem.name.local_name,
-                                            elem.name.namespace_uri.as_deref(),
-                                        ) {
-                                            self.validate_element(doc, child, &global_decl, errors);
-                                        }
-                                    }
-                                    ProcessContents::Strict => {
-                                        if let Some(global_decl) = self.find_global_element(
-                                            &elem.name.local_name,
-                                            elem.name.namespace_uri.as_deref(),
-                                        ) {
-                                            self.validate_element(doc, child, &global_decl, errors);
-                                        } else {
-                                            errors.push(ValidationError {
-                                                message: format!(
-                                                    "No global element declaration found for '{}' (strict wildcard)",
-                                                    elem.name.local_name
-                                                ),
-                                                line: Some(doc.node_line(child)),
-                                                column: Some(doc.node_column(child)),
-                                            });
-                                        }
+                        } if wildcard_allows_namespace(
+                            namespace_constraint,
+                            elem.name.namespace_uri.as_deref(),
+                        ) =>
+                        {
+                            matched[i] = true;
+                            match process_contents {
+                                ProcessContents::Skip => {}
+                                ProcessContents::Lax => {
+                                    if let Some(global_decl) = self.find_global_element(
+                                        &elem.name.local_name,
+                                        elem.name.namespace_uri.as_deref(),
+                                    ) {
+                                        self.validate_element(doc, child, &global_decl, errors);
                                     }
                                 }
-                                found = true;
-                                break;
+                                ProcessContents::Strict => {
+                                    if let Some(global_decl) = self.find_global_element(
+                                        &elem.name.local_name,
+                                        elem.name.namespace_uri.as_deref(),
+                                    ) {
+                                        self.validate_element(doc, child, &global_decl, errors);
+                                    } else {
+                                        errors.push(ValidationError {
+                                            message: format!(
+                                                "No global element declaration found for '{}' (strict wildcard)",
+                                                elem.name.local_name
+                                            ),
+                                            line: Some(doc.node_line(child)),
+                                            column: Some(doc.node_column(child)),
+                                        });
+                                    }
+                                }
                             }
+                            found = true;
+                            break;
                         }
                         _ => {}
                     }

--- a/src/xsd/wildcard.rs
+++ b/src/xsd/wildcard.rs
@@ -4,7 +4,7 @@
 //! constraints, computing the intersection and union of namespace constraints,
 //! and determining the stricter of two processContents values.
 //!
-//! These are used by [`AttributeWildcard`](super::types::AttributeWildcard) methods
+//! These are used by `AttributeWildcard` methods
 //! and by element wildcard validation in the validation module.
 
 use super::types::{NamespaceConstraint, ProcessContents};
@@ -34,6 +34,10 @@ pub(crate) fn wildcard_allows_namespace(
             None => uris.iter().any(|u| u == "##local"),
             Some(uri) => uris.iter().any(|u| u == uri),
         },
+        NamespaceConstraint::NotLocal => ns.is_some(),
+        NamespaceConstraint::Not(excluded) => {
+            matches!(ns, Some(uri) if !excluded.iter().any(|u| u == uri))
+        }
     }
 }
 
@@ -61,83 +65,48 @@ pub(super) fn intersect_namespace_constraints(
     a: &NamespaceConstraint,
     b: &NamespaceConstraint,
 ) -> Option<NamespaceConstraint> {
+    if let Some(finite) = finite_namespaces(a) {
+        return intersection_from_finite(finite, b);
+    }
+    if let Some(finite) = finite_namespaces(b) {
+        return intersection_from_finite(finite, a);
+    }
+
     match (a, b) {
         // Any intersected with anything is that thing
         (NamespaceConstraint::Any, other) | (other, NamespaceConstraint::Any) => {
             Some(other.clone())
         }
-        // Two lists: intersection of URI sets
-        (NamespaceConstraint::List(list_a), NamespaceConstraint::List(list_b)) => {
-            let result: Vec<String> = list_a
-                .iter()
-                .filter(|u| list_b.contains(u))
-                .cloned()
-                .collect();
-            if result.is_empty() {
-                None // empty intersection — no namespace allowed
-            } else {
-                Some(NamespaceConstraint::List(result))
+        (NamespaceConstraint::Other(a), NamespaceConstraint::Other(b)) => {
+            Some(excluding_namespaces([a.as_ref(), b.as_ref()]))
+        }
+        (NamespaceConstraint::Other(excluded), NamespaceConstraint::Not(other_excluded))
+        | (NamespaceConstraint::Not(other_excluded), NamespaceConstraint::Other(excluded)) => {
+            let mut excluded_uris = other_excluded.clone();
+            if let Some(uri) = excluded {
+                push_unique(&mut excluded_uris, uri.clone());
             }
+            Some(not_constraint(excluded_uris))
         }
-        // Other intersected with Other: still Other (same target)
-        (NamespaceConstraint::Other(tns_a), NamespaceConstraint::Other(_tns_b)) => {
-            Some(NamespaceConstraint::Other(tns_a.clone()))
+        (NamespaceConstraint::Other(excluded), NamespaceConstraint::NotLocal)
+        | (NamespaceConstraint::NotLocal, NamespaceConstraint::Other(excluded)) => {
+            Some(NamespaceConstraint::Other(excluded.clone()))
         }
-        // List intersected with Other: keep URIs from list that are not target NS
-        (NamespaceConstraint::List(list), NamespaceConstraint::Other(tns))
-        | (NamespaceConstraint::Other(tns), NamespaceConstraint::List(list)) => {
-            let result: Vec<String> = list
-                .iter()
-                .filter(|u| {
-                    if *u == "##local" {
-                        return false; // ##other excludes unqualified
-                    }
-                    match tns {
-                        Some(t) => *u != t,
-                        None => true,
-                    }
-                })
-                .cloned()
-                .collect();
-            if result.is_empty() {
-                None
-            } else {
-                Some(NamespaceConstraint::List(result))
+        (NamespaceConstraint::Not(a), NamespaceConstraint::Not(b)) => {
+            let mut excluded = a.clone();
+            for uri in b {
+                push_unique(&mut excluded, uri.clone());
             }
+            Some(not_constraint(excluded))
         }
-        // Local intersected with Local: Local
-        (NamespaceConstraint::Local, NamespaceConstraint::Local) => {
-            Some(NamespaceConstraint::Local)
+        (NamespaceConstraint::Not(excluded), NamespaceConstraint::NotLocal)
+        | (NamespaceConstraint::NotLocal, NamespaceConstraint::Not(excluded)) => {
+            Some(not_constraint(excluded.clone()))
         }
-        // Local intersected with Other: empty (Other excludes no-namespace)
-        (NamespaceConstraint::Local, NamespaceConstraint::Other(_))
-        | (NamespaceConstraint::Other(_), NamespaceConstraint::Local) => None,
-        // Local intersected with TargetNamespace: empty (disjoint)
-        (NamespaceConstraint::Local, NamespaceConstraint::TargetNamespace(_))
-        | (NamespaceConstraint::TargetNamespace(_), NamespaceConstraint::Local) => None,
-        // Local intersected with List: keep only ##local if present
-        (NamespaceConstraint::Local, NamespaceConstraint::List(list))
-        | (NamespaceConstraint::List(list), NamespaceConstraint::Local) => {
-            if list.iter().any(|u| u == "##local") {
-                Some(NamespaceConstraint::Local)
-            } else {
-                None
-            }
+        (NamespaceConstraint::NotLocal, NamespaceConstraint::NotLocal) => {
+            Some(NamespaceConstraint::NotLocal)
         }
-        // TargetNamespace intersected with TargetNamespace: same
-        (NamespaceConstraint::TargetNamespace(a_tns), NamespaceConstraint::TargetNamespace(_)) => {
-            Some(NamespaceConstraint::TargetNamespace(a_tns.clone()))
-        }
-        // TargetNamespace intersected with Other: empty (Other excludes target)
-        (NamespaceConstraint::TargetNamespace(_), NamespaceConstraint::Other(_))
-        | (NamespaceConstraint::Other(_), NamespaceConstraint::TargetNamespace(_)) => None,
-        // TargetNamespace intersected with List: keep target NS if in list
-        (NamespaceConstraint::TargetNamespace(tns), NamespaceConstraint::List(list))
-        | (NamespaceConstraint::List(list), NamespaceConstraint::TargetNamespace(tns)) => match tns
-        {
-            Some(t) if list.contains(t) => Some(NamespaceConstraint::TargetNamespace(tns.clone())),
-            _ => None,
-        },
+        _ => None,
     }
 }
 
@@ -150,20 +119,172 @@ pub(super) fn union_namespace_constraints(
     a: &NamespaceConstraint,
     b: &NamespaceConstraint,
 ) -> NamespaceConstraint {
+    if let (Some(mut finite_a), Some(finite_b)) = (finite_namespaces(a), finite_namespaces(b)) {
+        for ns in finite_b {
+            if !finite_a.contains(&ns) {
+                finite_a.push(ns);
+            }
+        }
+        return constraint_from_finite(finite_a).unwrap_or(NamespaceConstraint::Any);
+    }
+
     match (a, b) {
         // Any union anything = Any
         (NamespaceConstraint::Any, _) | (_, NamespaceConstraint::Any) => NamespaceConstraint::Any,
-        // Two lists: union of URI sets
-        (NamespaceConstraint::List(list_a), NamespaceConstraint::List(list_b)) => {
-            let mut result = list_a.clone();
-            for u in list_b {
-                if !result.contains(u) {
-                    result.push(u.clone());
+        (NamespaceConstraint::Other(a), NamespaceConstraint::Other(b)) => match (a, b) {
+            (Some(left), Some(right)) if left == right => NamespaceConstraint::Other(a.clone()),
+            (None, None) => NamespaceConstraint::Other(None),
+            _ => NamespaceConstraint::NotLocal,
+        },
+        (NamespaceConstraint::NotLocal, NamespaceConstraint::Local)
+        | (NamespaceConstraint::Local, NamespaceConstraint::NotLocal) => NamespaceConstraint::Any,
+        // `TargetNamespace(None)` is the no-namespace case (≡ `Local`). Its
+        // union with `NotLocal` (every non-empty namespace) covers all names,
+        // so the result is `Any` — not `NotLocal`, which would wrongly exclude
+        // no-namespace names.
+        (NamespaceConstraint::NotLocal, NamespaceConstraint::TargetNamespace(None))
+        | (NamespaceConstraint::TargetNamespace(None), NamespaceConstraint::NotLocal) => {
+            NamespaceConstraint::Any
+        }
+        (NamespaceConstraint::NotLocal, _) | (_, NamespaceConstraint::NotLocal) => {
+            NamespaceConstraint::NotLocal
+        }
+        (NamespaceConstraint::Other(excluded), NamespaceConstraint::TargetNamespace(Some(ns)))
+        | (NamespaceConstraint::TargetNamespace(Some(ns)), NamespaceConstraint::Other(excluded)) => {
+            if excluded.as_deref() == Some(ns.as_str()) {
+                NamespaceConstraint::NotLocal
+            } else {
+                NamespaceConstraint::Other(excluded.clone())
+            }
+        }
+        (NamespaceConstraint::Other(_), NamespaceConstraint::Local)
+        | (NamespaceConstraint::Local, NamespaceConstraint::Other(_)) => NamespaceConstraint::Any,
+        (NamespaceConstraint::Not(excluded), NamespaceConstraint::TargetNamespace(Some(ns)))
+        | (NamespaceConstraint::TargetNamespace(Some(ns)), NamespaceConstraint::Not(excluded)) => {
+            let reduced: Vec<String> = excluded.iter().filter(|u| *u != ns).cloned().collect();
+            not_constraint(reduced)
+        }
+        (NamespaceConstraint::Not(_), NamespaceConstraint::Local)
+        | (NamespaceConstraint::Local, NamespaceConstraint::Not(_)) => NamespaceConstraint::Any,
+        (NamespaceConstraint::Not(a), NamespaceConstraint::Not(b)) => {
+            let common: Vec<String> = a.iter().filter(|u| b.contains(u)).cloned().collect();
+            not_constraint(common)
+        }
+        _ => NamespaceConstraint::Any,
+    }
+}
+
+fn finite_namespaces(constraint: &NamespaceConstraint) -> Option<Vec<Option<String>>> {
+    match constraint {
+        NamespaceConstraint::Local => Some(vec![None]),
+        NamespaceConstraint::TargetNamespace(ns) => Some(vec![ns.clone()]),
+        NamespaceConstraint::List(uris) => {
+            let mut result = Vec::new();
+            for uri in uris {
+                let ns = if uri == "##local" {
+                    None
+                } else {
+                    Some(uri.clone())
+                };
+                if !result.contains(&ns) {
+                    result.push(ns);
                 }
             }
-            NamespaceConstraint::List(result)
+            Some(result)
         }
-        // Other cases: conservative fallback to Any
-        _ => NamespaceConstraint::Any,
+        _ => None,
+    }
+}
+
+fn intersection_from_finite(
+    finite: Vec<Option<String>>,
+    other: &NamespaceConstraint,
+) -> Option<NamespaceConstraint> {
+    let kept: Vec<Option<String>> = finite
+        .into_iter()
+        .filter(|ns| wildcard_allows_namespace(other, ns.as_deref()))
+        .collect();
+    constraint_from_finite(kept)
+}
+
+fn constraint_from_finite(values: Vec<Option<String>>) -> Option<NamespaceConstraint> {
+    let mut values = values;
+    values.dedup();
+    match values.as_slice() {
+        [] => None,
+        [None] => Some(NamespaceConstraint::Local),
+        [Some(uri)] => Some(NamespaceConstraint::TargetNamespace(Some(uri.clone()))),
+        _ => {
+            let mut uris = Vec::new();
+            for value in values {
+                match value {
+                    None => push_unique(&mut uris, "##local".to_string()),
+                    Some(uri) => push_unique(&mut uris, uri),
+                }
+            }
+            Some(NamespaceConstraint::List(uris))
+        }
+    }
+}
+
+fn excluding_namespaces<'a>(
+    exclusions: impl IntoIterator<Item = Option<&'a String>>,
+) -> NamespaceConstraint {
+    let mut excluded = Vec::new();
+    for uri in exclusions.into_iter().flatten() {
+        push_unique(&mut excluded, uri.clone());
+    }
+    not_constraint(excluded)
+}
+
+fn not_constraint(excluded: Vec<String>) -> NamespaceConstraint {
+    if excluded.is_empty() {
+        NamespaceConstraint::NotLocal
+    } else {
+        NamespaceConstraint::Not(excluded)
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn union_notlocal_with_no_target_namespace_is_any() {
+        // `TargetNamespace(None)` is the no-namespace case (≡ Local). Its
+        // union with NotLocal must cover every name → Any, not NotLocal
+        // (which would wrongly exclude no-namespace names).
+        let a = NamespaceConstraint::NotLocal;
+        let b = NamespaceConstraint::TargetNamespace(None);
+        assert!(matches!(
+            union_namespace_constraints(&a, &b),
+            NamespaceConstraint::Any
+        ));
+        assert!(matches!(
+            union_namespace_constraints(&b, &a),
+            NamespaceConstraint::Any
+        ));
+        // The resulting constraint must admit both no-namespace and any URI.
+        let result = union_namespace_constraints(&a, &b);
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:x")));
+    }
+
+    #[test]
+    fn union_notlocal_with_specific_target_namespace_stays_notlocal() {
+        // A specific (non-empty) target namespace is itself non-local, so the
+        // union with NotLocal contributes nothing new and remains NotLocal.
+        let a = NamespaceConstraint::NotLocal;
+        let b = NamespaceConstraint::TargetNamespace(Some("urn:x".into()));
+        assert!(matches!(
+            union_namespace_constraints(&a, &b),
+            NamespaceConstraint::NotLocal
+        ));
     }
 }

--- a/src/xsd/wildcard.rs
+++ b/src/xsd/wildcard.rs
@@ -38,6 +38,10 @@ pub(crate) fn wildcard_allows_namespace(
         NamespaceConstraint::Not(excluded) => {
             matches!(ns, Some(uri) if !excluded.iter().any(|u| u == uri))
         }
+        NamespaceConstraint::AnyExcept(excluded) => match ns {
+            None => true,
+            Some(uri) => !excluded.iter().any(|u| u == uri),
+        },
     }
 }
 
@@ -92,6 +96,14 @@ pub(super) fn intersect_namespace_constraints(
         | (NamespaceConstraint::NotLocal, NamespaceConstraint::Other(excluded)) => {
             Some(NamespaceConstraint::Other(excluded.clone()))
         }
+        (NamespaceConstraint::Other(excluded), NamespaceConstraint::AnyExcept(other_excluded))
+        | (NamespaceConstraint::AnyExcept(other_excluded), NamespaceConstraint::Other(excluded)) => {
+            let mut excluded_uris = other_excluded.clone();
+            if let Some(uri) = excluded {
+                push_unique(&mut excluded_uris, uri.clone());
+            }
+            Some(not_constraint(excluded_uris))
+        }
         (NamespaceConstraint::Not(a), NamespaceConstraint::Not(b)) => {
             let mut excluded = a.clone();
             for uri in b {
@@ -99,9 +111,28 @@ pub(super) fn intersect_namespace_constraints(
             }
             Some(not_constraint(excluded))
         }
+        (NamespaceConstraint::Not(excluded), NamespaceConstraint::AnyExcept(other_excluded))
+        | (NamespaceConstraint::AnyExcept(other_excluded), NamespaceConstraint::Not(excluded)) => {
+            let mut excluded_uris = excluded.clone();
+            for uri in other_excluded {
+                push_unique(&mut excluded_uris, uri.clone());
+            }
+            Some(not_constraint(excluded_uris))
+        }
         (NamespaceConstraint::Not(excluded), NamespaceConstraint::NotLocal)
         | (NamespaceConstraint::NotLocal, NamespaceConstraint::Not(excluded)) => {
             Some(not_constraint(excluded.clone()))
+        }
+        (NamespaceConstraint::NotLocal, NamespaceConstraint::AnyExcept(excluded))
+        | (NamespaceConstraint::AnyExcept(excluded), NamespaceConstraint::NotLocal) => {
+            Some(not_constraint(excluded.clone()))
+        }
+        (NamespaceConstraint::AnyExcept(a), NamespaceConstraint::AnyExcept(b)) => {
+            let mut excluded = a.clone();
+            for uri in b {
+                push_unique(&mut excluded, uri.clone());
+            }
+            Some(any_except_constraint(excluded))
         }
         (NamespaceConstraint::NotLocal, NamespaceConstraint::NotLocal) => {
             Some(NamespaceConstraint::NotLocal)
@@ -127,10 +158,55 @@ pub(super) fn union_namespace_constraints(
         }
         return constraint_from_finite(finite_a).unwrap_or(NamespaceConstraint::Any);
     }
+    if let Some(finite) = finite_namespaces(a) {
+        match b {
+            NamespaceConstraint::Other(excluded) => {
+                return union_other_with_finite(excluded, finite)
+            }
+            NamespaceConstraint::NotLocal => return union_notlocal_with_finite(finite),
+            NamespaceConstraint::Not(excluded) => return union_not_with_finite(excluded, finite),
+            NamespaceConstraint::AnyExcept(excluded) => {
+                return union_any_except_with_finite(excluded, finite);
+            }
+            _ => {}
+        }
+    }
+    if let Some(finite) = finite_namespaces(b) {
+        match a {
+            NamespaceConstraint::Other(excluded) => {
+                return union_other_with_finite(excluded, finite)
+            }
+            NamespaceConstraint::NotLocal => return union_notlocal_with_finite(finite),
+            NamespaceConstraint::Not(excluded) => return union_not_with_finite(excluded, finite),
+            NamespaceConstraint::AnyExcept(excluded) => {
+                return union_any_except_with_finite(excluded, finite);
+            }
+            _ => {}
+        }
+    }
 
     match (a, b) {
         // Any union anything = Any
         (NamespaceConstraint::Any, _) | (_, NamespaceConstraint::Any) => NamespaceConstraint::Any,
+        (NamespaceConstraint::AnyExcept(excluded), NamespaceConstraint::Other(other))
+        | (NamespaceConstraint::Other(other), NamespaceConstraint::AnyExcept(excluded)) => {
+            let common = match other {
+                Some(uri) if excluded.contains(uri) => vec![uri.clone()],
+                _ => Vec::new(),
+            };
+            any_except_constraint(common)
+        }
+        (NamespaceConstraint::AnyExcept(_), NamespaceConstraint::NotLocal)
+        | (NamespaceConstraint::NotLocal, NamespaceConstraint::AnyExcept(_)) => {
+            NamespaceConstraint::Any
+        }
+        (NamespaceConstraint::AnyExcept(a), NamespaceConstraint::Not(b))
+        | (NamespaceConstraint::Not(b), NamespaceConstraint::AnyExcept(a)) => {
+            any_except_constraint(common_exclusions(a, b))
+        }
+        (NamespaceConstraint::AnyExcept(a), NamespaceConstraint::AnyExcept(b)) => {
+            any_except_constraint(common_exclusions(a, b))
+        }
         (NamespaceConstraint::Other(a), NamespaceConstraint::Other(b)) => match (a, b) {
             (Some(left), Some(right)) if left == right => NamespaceConstraint::Other(a.clone()),
             (None, None) => NamespaceConstraint::Other(None),
@@ -151,15 +227,20 @@ pub(super) fn union_namespace_constraints(
                 NamespaceConstraint::Other(excluded.clone())
             }
         }
-        (NamespaceConstraint::Other(_), NamespaceConstraint::Local)
-        | (NamespaceConstraint::Local, NamespaceConstraint::Other(_)) => NamespaceConstraint::Any,
+        (NamespaceConstraint::Other(excluded), NamespaceConstraint::Local)
+        | (NamespaceConstraint::Local, NamespaceConstraint::Other(excluded)) => match excluded {
+            Some(uri) => any_except_constraint(vec![uri.clone()]),
+            None => NamespaceConstraint::Any,
+        },
         (NamespaceConstraint::Not(excluded), NamespaceConstraint::TargetNamespace(Some(ns)))
         | (NamespaceConstraint::TargetNamespace(Some(ns)), NamespaceConstraint::Not(excluded)) => {
             let reduced: Vec<String> = excluded.iter().filter(|u| *u != ns).cloned().collect();
             not_constraint(reduced)
         }
-        (NamespaceConstraint::Not(_), NamespaceConstraint::Local)
-        | (NamespaceConstraint::Local, NamespaceConstraint::Not(_)) => NamespaceConstraint::Any,
+        (NamespaceConstraint::Not(excluded), NamespaceConstraint::Local)
+        | (NamespaceConstraint::Local, NamespaceConstraint::Not(excluded)) => {
+            any_except_constraint(excluded.clone())
+        }
         (NamespaceConstraint::Not(a), NamespaceConstraint::Not(b)) => {
             let common: Vec<String> = a.iter().filter(|u| b.contains(u)).cloned().collect();
             not_constraint(common)
@@ -206,12 +287,20 @@ fn intersection_from_finite(
 }
 
 fn constraint_from_finite(values: Vec<Option<String>>) -> Option<NamespaceConstraint> {
+    // Sort + dedup so the result is deterministic and duplicate-free regardless
+    // of input ordering. Plain `dedup` only removes *adjacent* duplicates, so a
+    // non-adjacent repeat (e.g. `[a, b, a]`) would otherwise slip through.
     let mut values = values;
+    values.sort();
     values.dedup();
     match values.as_slice() {
         [] => None,
         [None] => Some(NamespaceConstraint::Local),
-        [Some(uri)] => Some(NamespaceConstraint::TargetNamespace(Some(uri.clone()))),
+        // A single explicit URI is just the set `{uri}`. Represent it as a
+        // one-element `List`, not `TargetNamespace`: the latter carries dedicated
+        // `##targetNamespace` semantics that the union/intersection arms special-
+        // case, so reusing it for an arbitrary singleton can skew wildcard merges.
+        [Some(uri)] => Some(NamespaceConstraint::List(vec![uri.clone()])),
         _ => {
             let mut uris = Vec::new();
             for value in values {
@@ -241,6 +330,84 @@ fn not_constraint(excluded: Vec<String>) -> NamespaceConstraint {
     } else {
         NamespaceConstraint::Not(excluded)
     }
+}
+
+fn any_except_constraint(excluded: Vec<String>) -> NamespaceConstraint {
+    let mut deduped = Vec::new();
+    for uri in excluded {
+        push_unique(&mut deduped, uri);
+    }
+    if deduped.is_empty() {
+        NamespaceConstraint::Any
+    } else {
+        NamespaceConstraint::AnyExcept(deduped)
+    }
+}
+
+fn common_exclusions(a: &[String], b: &[String]) -> Vec<String> {
+    a.iter().filter(|u| b.contains(u)).cloned().collect()
+}
+
+fn union_other_with_finite(
+    excluded: &Option<String>,
+    finite: Vec<Option<String>>,
+) -> NamespaceConstraint {
+    let includes_local = finite.contains(&None);
+    match excluded {
+        Some(uri) if finite.contains(&Some(uri.clone())) => {
+            if includes_local {
+                NamespaceConstraint::Any
+            } else {
+                NamespaceConstraint::NotLocal
+            }
+        }
+        Some(uri) => {
+            if includes_local {
+                any_except_constraint(vec![uri.clone()])
+            } else {
+                NamespaceConstraint::Other(Some(uri.clone()))
+            }
+        }
+        None => {
+            if includes_local {
+                NamespaceConstraint::Any
+            } else {
+                NamespaceConstraint::NotLocal
+            }
+        }
+    }
+}
+
+fn union_notlocal_with_finite(finite: Vec<Option<String>>) -> NamespaceConstraint {
+    if finite.contains(&None) {
+        NamespaceConstraint::Any
+    } else {
+        NamespaceConstraint::NotLocal
+    }
+}
+
+fn union_not_with_finite(excluded: &[String], finite: Vec<Option<String>>) -> NamespaceConstraint {
+    let includes_local = finite.contains(&None);
+    let mut reduced = excluded.to_vec();
+    for ns in finite.into_iter().flatten() {
+        reduced.retain(|excluded_ns| excluded_ns != &ns);
+    }
+    if includes_local {
+        any_except_constraint(reduced)
+    } else {
+        not_constraint(reduced)
+    }
+}
+
+fn union_any_except_with_finite(
+    excluded: &[String],
+    finite: Vec<Option<String>>,
+) -> NamespaceConstraint {
+    let mut reduced = excluded.to_vec();
+    for ns in finite.into_iter().flatten() {
+        reduced.retain(|excluded_ns| excluded_ns != &ns);
+    }
+    any_except_constraint(reduced)
 }
 
 fn push_unique(values: &mut Vec<String>, value: String) {
@@ -300,5 +467,39 @@ mod tests {
             union_namespace_constraints(&a, &b),
             NamespaceConstraint::NotLocal
         ));
+    }
+
+    #[test]
+    fn union_other_with_local_excludes_target_namespace() {
+        let other = NamespaceConstraint::Other(Some("urn:t".into()));
+        let local = NamespaceConstraint::Local;
+
+        let result = union_namespace_constraints(&other, &local);
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:f")));
+        assert!(!wildcard_allows_namespace(&result, Some("urn:t")));
+
+        let result = union_namespace_constraints(&local, &other);
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:f")));
+        assert!(!wildcard_allows_namespace(&result, Some("urn:t")));
+    }
+
+    #[test]
+    fn union_other_with_finite_list_is_precise() {
+        let other = NamespaceConstraint::Other(Some("urn:t".into()));
+        let list = NamespaceConstraint::List(vec!["##local".into(), "urn:f".into()]);
+
+        let result = union_namespace_constraints(&other, &list);
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:f")));
+        assert!(wildcard_allows_namespace(&result, Some("urn:g")));
+        assert!(!wildcard_allows_namespace(&result, Some("urn:t")));
+
+        let list = NamespaceConstraint::List(vec!["urn:t".into()]);
+        let result = union_namespace_constraints(&other, &list);
+        assert!(wildcard_allows_namespace(&result, Some("urn:t")));
+        assert!(wildcard_allows_namespace(&result, Some("urn:g")));
+        assert!(!wildcard_allows_namespace(&result, None));
     }
 }

--- a/src/xsd/wildcard.rs
+++ b/src/xsd/wildcard.rs
@@ -136,18 +136,12 @@ pub(super) fn union_namespace_constraints(
             (None, None) => NamespaceConstraint::Other(None),
             _ => NamespaceConstraint::NotLocal,
         },
-        (NamespaceConstraint::NotLocal, NamespaceConstraint::Local)
-        | (NamespaceConstraint::Local, NamespaceConstraint::NotLocal) => NamespaceConstraint::Any,
-        // `TargetNamespace(None)` is the no-namespace case (≡ `Local`). Its
-        // union with `NotLocal` (every non-empty namespace) covers all names,
-        // so the result is `Any` — not `NotLocal`, which would wrongly exclude
-        // no-namespace names.
-        (NamespaceConstraint::NotLocal, NamespaceConstraint::TargetNamespace(None))
-        | (NamespaceConstraint::TargetNamespace(None), NamespaceConstraint::NotLocal) => {
-            NamespaceConstraint::Any
-        }
-        (NamespaceConstraint::NotLocal, _) | (_, NamespaceConstraint::NotLocal) => {
-            NamespaceConstraint::NotLocal
+        (NamespaceConstraint::NotLocal, other) | (other, NamespaceConstraint::NotLocal) => {
+            if finite_includes_local(other) {
+                NamespaceConstraint::Any
+            } else {
+                NamespaceConstraint::NotLocal
+            }
         }
         (NamespaceConstraint::Other(excluded), NamespaceConstraint::TargetNamespace(Some(ns)))
         | (NamespaceConstraint::TargetNamespace(Some(ns)), NamespaceConstraint::Other(excluded)) => {
@@ -194,6 +188,10 @@ fn finite_namespaces(constraint: &NamespaceConstraint) -> Option<Vec<Option<Stri
         }
         _ => None,
     }
+}
+
+fn finite_includes_local(constraint: &NamespaceConstraint) -> bool {
+    finite_namespaces(constraint).is_some_and(|namespaces| namespaces.contains(&None))
 }
 
 fn intersection_from_finite(
@@ -272,6 +270,22 @@ mod tests {
         ));
         // The resulting constraint must admit both no-namespace and any URI.
         let result = union_namespace_constraints(&a, &b);
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:x")));
+    }
+
+    #[test]
+    fn union_notlocal_with_local_list_is_any() {
+        let a = NamespaceConstraint::NotLocal;
+        let b = NamespaceConstraint::List(vec!["##local".into(), "urn:extra".into()]);
+
+        let result = union_namespace_constraints(&a, &b);
+        assert!(matches!(result, NamespaceConstraint::Any));
+        assert!(wildcard_allows_namespace(&result, None));
+        assert!(wildcard_allows_namespace(&result, Some("urn:x")));
+
+        let result = union_namespace_constraints(&b, &a);
+        assert!(matches!(result, NamespaceConstraint::Any));
         assert!(wildcard_allows_namespace(&result, None));
         assert!(wildcard_allows_namespace(&result, Some("urn:x")));
     }

--- a/src/xsd_regex.rs
+++ b/src/xsd_regex.rs
@@ -480,6 +480,9 @@ fn parse_escape(chars: &[char], pos: &mut usize) -> Result<RegexNode, String> {
                 }
                 let name: String = chars[start..*pos].iter().collect();
                 *pos += 1; // skip '}'
+                if !is_known_property_name(&name) {
+                    return Err(format!("Unknown Unicode property '{}'", name));
+                }
                 Ok(RegexNode::CharClass(CharClass {
                     negated: false,
                     members: vec![ClassMember::Property(UnicodeProperty { negated, name })],
@@ -629,6 +632,9 @@ fn parse_class_atom(chars: &[char], pos: &mut usize) -> Result<ClassMember, Stri
                         }
                         let name: String = chars[start..*pos].iter().collect();
                         *pos += 1;
+                        if !is_known_property_name(&name) {
+                            return Err(format!("Unknown Unicode property '{}'", name));
+                        }
                         Ok(ClassMember::Property(UnicodeProperty { negated, name }))
                     } else {
                         Err("Expected '{' after \\p or \\P in character class".into())
@@ -757,21 +763,12 @@ fn match_repetition(
         current_positions = next;
     }
 
-    // Greedy loop accumulator: a direct-indexed `seen` bitmap (positions
-    // are bounded by `input.len()`) gives O(1) membership test per
-    // candidate. Combined with a parallel `results` Vec that holds only
-    // the unique reachable end-positions, total work is O(N) insertions
-    // plus one O(N log N) final sort — vs the O(N^2) cost a
-    // merge-into-sorted-vec accumulator would incur on linear patterns
-    // like `[a-z]+` over a long string of `a`s.
-    let mut seen: Vec<bool> = vec![false; input.len() + 1];
-    let mut results: Vec<usize> = Vec::new();
-    for &p in &current_positions {
-        if p < seen.len() && !seen[p] {
-            seen[p] = true;
-            results.push(p);
-        }
-    }
+    // `results` accumulates the unique reachable end-positions. The initial
+    // positions are typically already sorted+deduped (from the required-min
+    // loop, or a single start position), so a cheap sort+dedup suffices.
+    let mut results: Vec<usize> = current_positions.clone();
+    results.sort_unstable();
+    results.dedup();
 
     // Defence-in-depth: `parse_brace_quantifier` rejects `{n,m}` with
     // `m < n` at compile time, so reaching the panic-on-underflow path
@@ -785,6 +782,16 @@ fn match_repetition(
         None => input.len().saturating_add(1), // More than enough
     };
 
+    // The `seen` membership bitmap is sized to `input.len()` — an O(N)
+    // allocation. It is materialized LAZILY, only on the first greedy
+    // iteration that actually advances. A repetition that cannot match even
+    // once (the common `a*b*`-over-`aaaa…` shape, where the inner atom fails
+    // immediately) therefore never pays the O(N) allocation. Without this, an
+    // outer repetition that invokes `match_repetition` O(N) times would incur
+    // an O(N) allocation each time — O(N^2) total work that the per-`match_node`
+    // step budget cannot bound, since a single tick covers an O(N) memset.
+    let mut seen: Vec<bool> = Vec::new();
+
     for _ in 0..remaining {
         let mut next = Vec::new();
         for &pos in &current_positions {
@@ -794,6 +801,17 @@ fn match_repetition(
         next.dedup();
         if next.is_empty() {
             break;
+        }
+
+        if seen.is_empty() {
+            // First productive iteration: build the bitmap and seed it with the
+            // end-positions already in `results`.
+            seen = vec![false; input.len() + 1];
+            for &p in &results {
+                if p < seen.len() {
+                    seen[p] = true;
+                }
+            }
         }
 
         let mut added = false;
@@ -1017,7 +1035,11 @@ fn is_extender(ch: char) -> bool {
 
 /// Match Unicode property \p{...} or \P{...}.
 fn property_matches(prop: &UnicodeProperty, ch: char) -> bool {
-    let base_match = match_property_name(&prop.name, ch);
+    // Unknown property names are rejected at compile time (see
+    // `is_known_property_name`), so they cannot reach here. Treat the
+    // impossible unknown case as "matches nothing" (fail-closed) so a
+    // future regression can never make `\P{unknown}` admit every char.
+    let base_match = match_property_name(&prop.name, ch).unwrap_or(false);
     if prop.negated {
         !base_match
     } else {
@@ -1025,9 +1047,26 @@ fn property_matches(prop: &UnicodeProperty, ch: char) -> bool {
     }
 }
 
-/// Match a Unicode general category or block name.
-fn match_property_name(name: &str, ch: char) -> bool {
-    match name {
+/// Returns `true` if `name` is a recognized Unicode general category or block.
+///
+/// Unknown property names must be rejected at compile time: otherwise
+/// `\p{unknown}` matches nothing and `\P{unknown}` matches *every* character,
+/// silently widening a pattern (a validation bypass). The supplied char is
+/// irrelevant to known-ness — a recognized property yields `Some(_)` and an
+/// unrecognized one yields `None`.
+///
+/// The recognized set is the **closed** list XSD 1.0 Part 2 defines: the Unicode
+/// general categories plus the Appendix-F `IsBlock` names (see
+/// [`match_unicode_block`]). A name outside that list is not a valid escape, so
+/// rejecting it is spec-correct rather than an over-restriction.
+fn is_known_property_name(name: &str) -> bool {
+    match_property_name(name, 'a').is_some()
+}
+
+/// Match a Unicode general category or block name. Returns `None` when `name`
+/// is not a recognized property (so callers can fail closed).
+fn match_property_name(name: &str, ch: char) -> Option<bool> {
+    let matched = match name {
         // General categories
         "L" => ch.is_alphabetic(),
         "Lu" => ch.is_uppercase(),
@@ -1066,9 +1105,10 @@ fn match_property_name(name: &str, ch: char) -> bool {
         "Co" => is_private_use(ch),
         "Cn" => !ch.is_alphanumeric() && !is_assigned(ch),
         // Unicode block escapes (Is...)
-        _ if name.starts_with("Is") => match_unicode_block(&name[2..], ch),
-        _ => false,
-    }
+        _ if name.starts_with("Is") => return match_unicode_block(&name[2..], ch),
+        _ => return None,
+    };
+    Some(matched)
 }
 
 // ─── Unicode category helpers ────────────────────────────────────────────────
@@ -1690,9 +1730,19 @@ fn is_assigned(ch: char) -> bool {
 
 // ─── Unicode Block matching ─────────────────────────────────────────────────
 
-fn match_unicode_block(block_name: &str, ch: char) -> bool {
+/// Match a Unicode block name (the part after `Is`). Returns `None` when the
+/// block name is not recognized so callers can fail closed.
+///
+/// The recognized names are the **closed** set of `IsBlock` identifiers defined
+/// by XSD 1.0 Part 2 Appendix F (the Unicode 3.1 block list), plus a few later
+/// blocks. Because XSD defines this as a closed list, a name outside it is not a
+/// valid block escape and is correctly rejected at compile time (`None`) rather
+/// than silently matching nothing — which would let `\P{IsTypo}` match every
+/// character (a validation bypass). Adding a genuinely new block is therefore a
+/// deliberate table edit, not an open-ended fallback.
+fn match_unicode_block(block_name: &str, ch: char) -> Option<bool> {
     let c = ch as u32;
-    match block_name {
+    let matched = match block_name {
         "BasicLatin" => (0x0000..=0x007F).contains(&c),
         "Latin-1Supplement" => (0x0080..=0x00FF).contains(&c),
         "LatinExtended-A" => (0x0100..=0x017F).contains(&c),
@@ -1809,8 +1859,9 @@ fn match_unicode_block(block_name: &str, ch: char) -> bool {
         "CJKUnifiedIdeographsExtensionB" => (0x20000..=0x2A6DF).contains(&c),
         "CJKCompatibilityIdeographsSupplement" => (0x2F800..=0x2FA1F).contains(&c),
         "Tags" => (0xE0000..=0xE007F).contains(&c),
-        _ => false,
-    }
+        _ => return None,
+    };
+    Some(matched)
 }
 
 #[cfg(test)]

--- a/tests/hardening_regressions.rs
+++ b/tests/hardening_regressions.rs
@@ -1,0 +1,305 @@
+//! Regression tests for the core security-hardening review findings.
+//!
+//! Each test pins a specific vulnerability fixed in the differential review of
+//! the `feat/harden` branch. (Findings specific to the XPath 2.0 engine are not
+//! included on this security-only branch.) The findings fall into three classes:
+//!
+//! * **Uncatchable aborts** (stack overflow): F7 (deep linear entity chains).
+//!   Before the fix this aborted the whole process via `SIGABRT`; after the fix
+//!   it returns a normal `Err`. NOTE: if the fix regresses, the test will abort
+//!   the test binary rather than fail cleanly — that is intentional and loud.
+//! * **Panics** (catchable): F8 (datetime multibyte slicing), F11 (`substring`
+//!   overflow). Verified with `catch_unwind`.
+//! * **Resource exhaustion / correctness** (no crash, but pathological cost or
+//!   wrong output): F5 (uncharged O(n·m) work), F4 (quadratic regex
+//!   allocation), F6 (PI-target markup injection), F10 (duplicate namespace
+//!   declarations), F12 (unknown Unicode property bypass).
+//!
+//! Every group also includes a "legitimate input still works" assertion so a
+//! future tightening of a limit cannot silently break valid documents.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::time::{Duration, Instant};
+
+use uppsala::{parse, NodeKind, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
+
+// ─── F4 — XSD regex repetition must not be quadratic-time (budget bypass) ─────
+
+fn validate_pattern(pattern: &str, body: &str) -> bool {
+    let schema = format!(
+        r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:element name="x"><xs:simpleType><xs:restriction base="xs:string">
+          <xs:pattern value="{pattern}"/></xs:restriction></xs:simpleType></xs:element></xs:schema>"#
+    );
+    let sd = parse(&schema).unwrap();
+    let validator = XsdValidator::from_schema(&sd).unwrap();
+    let instance_xml = format!("<x>{body}</x>");
+    let inst = parse(&instance_xml).unwrap();
+    validator.validate(&inst).is_empty()
+}
+
+#[test]
+fn f4_repetition_pattern_is_near_linear_and_correct() {
+    // `a*b*` over a long run of `a` previously allocated an O(N) bitmap per
+    // candidate position — O(N^2) work uncharged by the step budget. The lazy
+    // allocation makes it ~linear AND still correct (the value validates).
+    let n = 400_000;
+    let body = "a".repeat(n);
+    let start = Instant::now();
+    assert!(
+        validate_pattern("a*b*", &body),
+        "a* over a long string of 'a's must still match"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(3),
+        "match must stay near-linear, took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn f4_repetition_pattern_rejects_non_matching_input() {
+    // Correctness guard: the lazy-allocation rewrite must not make a
+    // non-matching value pass.
+    assert!(
+        !validate_pattern("a*b*", "abab"),
+        "`a*b*` must reject interleaved input"
+    );
+}
+
+// ─── F5 — XPath 1.0 node-set comparison must be charged ──────────────────────
+
+#[test]
+fn f5_disjoint_nodeset_comparison_is_bounded() {
+    // `/r/a = /r/b` over disjoint-valued sets built via a cheap child-axis path
+    // forced a full O(n·m) string-value scan that the node-visit budget did not
+    // charge — minutes of CPU. It now fails fast.
+    let mut s = String::from("<r>");
+    for _ in 0..16_000 {
+        s.push_str("<a>x</a>");
+    }
+    for _ in 0..16_000 {
+        s.push_str("<b>y</b>");
+    }
+    s.push_str("</r>");
+    let mut doc = parse(&s).unwrap();
+    doc.prepare_xpath();
+    let root = doc.root();
+    let evaluator = XPathEvaluator::new();
+    let start = Instant::now();
+    let result = evaluator.evaluate(&doc, root, "/r/a = /r/b");
+    assert!(
+        result.is_err(),
+        "large disjoint comparison must hit the budget"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "must fail fast, took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn f5_small_nodeset_comparison_is_correct() {
+    // The charge must not break ordinary comparisons: 2 == 2 is true.
+    let mut doc = parse("<r><a>1</a><a>2</a><b>2</b></r>").unwrap();
+    doc.prepare_xpath();
+    let root = doc.root();
+    let evaluator = XPathEvaluator::new();
+    let value = evaluator.evaluate(&doc, root, "/r/a = /r/b").unwrap();
+    assert!(
+        value.to_boolean(),
+        "node-sets sharing the value 2 compare equal"
+    );
+}
+
+// ─── F6 — Processing-instruction target must be sanitized ────────────────────
+
+/// Count element children of the document element in `xml`.
+fn count_root_child_elements(xml: &str) -> usize {
+    let doc = parse(xml).expect("serialized output must re-parse");
+    let root = doc.document_element().expect("document element");
+    doc.children_iter(root)
+        .filter(|&c| matches!(doc.node_kind(c), Some(NodeKind::Element(_))))
+        .count()
+}
+
+#[test]
+fn f6_pi_target_cannot_smuggle_markup() {
+    // A PI target containing `?>` plus markup previously broke out of PI
+    // position and injected a sibling element. The target is now validated as
+    // an NCName (collapsing to `_` when invalid).
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[]);
+    w.processing_instruction("foo?><evil>boom</evil><?x", None);
+    w.end_element("r");
+    let xml = w.into_string();
+    assert!(
+        !xml.contains("<evil>"),
+        "markup must not be smuggled: {xml}"
+    );
+    assert_eq!(
+        count_root_child_elements(&xml),
+        0,
+        "no sibling element may be injected via the PI target: {xml}"
+    );
+}
+
+#[test]
+fn f6_reserved_and_valid_pi_targets_are_preserved() {
+    // The reserved `xml` target is renamed; a normal target round-trips.
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[]);
+    w.processing_instruction("xml", Some("v"));
+    w.processing_instruction("xml-stylesheet", Some("type=\"text/xsl\""));
+    w.end_element("r");
+    let xml = w.into_string();
+    assert!(xml.contains("<?_xml"), "reserved target renamed: {xml}");
+    assert!(
+        xml.contains("<?xml-stylesheet"),
+        "valid target preserved: {xml}"
+    );
+    assert!(parse(&xml).is_ok());
+}
+
+// ─── F7 — Deep linear entity chains must not overflow the stack ──────────────
+
+#[test]
+fn f7_deep_entity_chain_fails_closed() {
+    // e0 -> e1 -> ... -> eN with a tiny leaf expands to ~1 byte (so the byte
+    // budget never trips) yet recursed N frames deep. The depth cap now rejects
+    // it with a normal error instead of aborting the process.
+    let n = 2_000;
+    let mut dtd = String::from("<!DOCTYPE r [\n");
+    for i in 0..n {
+        dtd.push_str(&format!("<!ENTITY e{i} \"&e{};\">", i + 1));
+    }
+    dtd.push_str(&format!("<!ENTITY e{n} \"x\">\n]>\n<r>&e0;</r>"));
+    assert!(parse(&dtd).is_err(), "deep entity chain must fail closed");
+}
+
+#[test]
+fn f7_shallow_entity_nesting_still_expands() {
+    // A handful of nested entities must still resolve normally.
+    let doc = parse(
+        "<!DOCTYPE r [<!ENTITY a \"A\"><!ENTITY b \"&a;&a;\"><!ENTITY c \"&b;&b;\">]><r>&c;</r>",
+    )
+    .expect("shallow entity nesting must parse");
+    let root = doc.document_element().unwrap();
+    assert_eq!(doc.element_text(root), Some("AAAA"));
+}
+
+// ─── F8 — datetime validators must not panic on multibyte input ──────────────
+
+/// Validate a single-element instance whose type is `type_name` and text is
+/// `text`, returning whether validation succeeded (no errors). Panics are
+/// surfaced so the test can assert they do not occur.
+fn validate_typed_text(type_name: &str, text: &str) -> Result<bool, ()> {
+    let schema = format!(
+        r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:element name="x" type="xs:{type_name}"/></xs:schema>"#
+    );
+    let sd = parse(&schema).unwrap();
+    let validator = XsdValidator::from_schema(&sd).unwrap();
+    let instance_xml = format!("<x>{text}</x>");
+    let inst = parse(&instance_xml).unwrap();
+    catch_unwind(AssertUnwindSafe(|| validator.validate(&inst).is_empty())).map_err(|_| ())
+}
+
+#[test]
+fn f8_gmonth_gday_gmonthday_reject_multibyte_without_panic() {
+    // Fixed byte-index slices (`&s[2..4]` etc.) panicked when a multibyte char
+    // straddled the slice boundary. The validators now reject non-ASCII up
+    // front. Each must return "invalid" (Ok(false)), never panic (Err).
+    for (ty, text) in [
+        ("gMonth", "--\u{20AC}"), // <x>--€</x>
+        ("gDay", "---\u{20AC}"),  // <x>---€</x>
+        ("gMonthDay", "--\u{20AC}-01"),
+    ] {
+        match validate_typed_text(ty, text) {
+            Ok(valid) => assert!(!valid, "{ty} must reject multibyte input"),
+            Err(()) => panic!("{ty} validation panicked on multibyte input"),
+        }
+    }
+}
+
+#[test]
+fn f8_valid_gmonth_still_accepted() {
+    assert_eq!(validate_typed_text("gMonth", "--05"), Ok(true));
+}
+
+// ─── F10 — namespace-declaration collisions must not duplicate attributes ────
+
+#[test]
+fn f10_colliding_ns_prefixes_produce_well_formed_output() {
+    use std::borrow::Cow;
+    use uppsala::dom::QName;
+    use uppsala::Document;
+
+    // Two distinct invalid prefixes both sanitize to `_`. The serializer must
+    // disambiguate them so the output has no duplicate `xmlns:_` attribute and
+    // re-parses cleanly.
+    let mut doc = Document::new();
+    let root = doc.root();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(root, el);
+    if let Some(NodeKind::Element(e)) = doc.node_kind_mut(el) {
+        e.namespace_declarations
+            .push((Cow::Owned("a b".into()), Cow::Owned("urn:1".into())));
+        e.namespace_declarations
+            .push((Cow::Owned("c d".into()), Cow::Owned("urn:2".into())));
+    }
+    let xml = doc.to_xml();
+    assert!(
+        parse(&xml).is_ok(),
+        "ns-declaration output must re-parse as well-formed: {xml}"
+    );
+}
+
+// ─── F11 — XPath 1.0 substring() must not overflow ───────────────────────────
+
+#[test]
+fn f11_substring_overflow_is_clamped_not_panicked() {
+    // `substring(s, start, +inf)` coerced length to usize::MAX; `start + len`
+    // overflowed. `saturating_add` + clamp now returns the remaining string.
+    let mut doc = parse("<r/>").unwrap();
+    doc.prepare_xpath();
+    let root = doc.root();
+    let evaluator = XPathEvaluator::new();
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        evaluator.evaluate(&doc, root, "substring('hello', 2, 1 div 0)")
+    }));
+    let value = result
+        .expect("substring must not panic on overflow")
+        .expect("evaluation succeeds");
+    assert_eq!(value.to_string_value(&doc), "ello");
+}
+
+// ─── F12 — XSD regex must reject unknown Unicode properties/blocks ───────────
+
+#[test]
+fn f12_unknown_unicode_property_rejected() {
+    // Unknown category/block names must fail to compile (fail-closed), so
+    // `\P{IsTypo}` cannot match every character.
+    assert!(XsdRegex::compile("\\P{unknowncategory}+").is_err());
+    assert!(XsdRegex::compile("\\p{unknowncategory}+").is_err());
+    assert!(XsdRegex::compile("\\p{IsNotARealBlock}+").is_err());
+    assert!(XsdRegex::compile("[\\p{unknowncategory}]").is_err());
+}
+
+#[test]
+fn f12_known_categories_and_blocks_still_compile() {
+    // Valid general categories and the XSD 1.0 block names must still compile.
+    for pattern in [
+        "\\p{Lu}+",
+        "\\P{Nd}+",
+        "\\p{IsBasicLatin}+",
+        "\\p{IsGreek}+",
+        "\\p{IsCJKUnifiedIdeographs}+",
+    ] {
+        assert!(
+            XsdRegex::compile(pattern).is_ok(),
+            "valid pattern must compile: {pattern}"
+        );
+    }
+}

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -5,38 +5,9 @@
 //! `#[ignore]` so the default `cargo test` run remains safe; invoke them
 //! explicitly with `cargo test --test security_audit -- --ignored`.
 //!
-//! Tests that time-bound a DoS use a worker thread plus a wall-clock
-//! timeout — if the worker doesn't finish within `TIMEOUT`, the test fails
-//! with "DoS: took > TIMEOUT".
-
-use std::sync::mpsc;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use uppsala::{parse, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
-
-// Wall-clock cap for DoS tests. Well under a typical cargo-test default.
-const TIMEOUT: Duration = Duration::from_secs(5);
-
-fn run_with_timeout<F, R>(label: &'static str, f: F) -> R
-where
-    F: FnOnce() -> R + Send + 'static,
-    R: Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let r = f();
-        let _ = tx.send(r);
-    });
-    match rx.recv_timeout(TIMEOUT) {
-        Ok(v) => v,
-        Err(_) => panic!(
-            "{}: exceeded {}s timeout (DoS confirmed)",
-            label,
-            TIMEOUT.as_secs()
-        ),
-    }
-}
 
 // ─── Finding F-01 — Billion Laughs (entity expansion) ──────────────────
 
@@ -170,15 +141,18 @@ fn xsd_regex_deep_paren_stack_overflow() {
 #[test]
 fn xsd_regex_polynomial_redos() {
     // (a*)*b against N 'a's. Matcher is O(n^3)/O(n^4); at N=200
-    // it should finish quickly. If the dedup guard regresses, this
-    // will blow past TIMEOUT.
+    // it should finish quickly under the matcher step budget.
     let re = XsdRegex::compile("(a*)*b").expect("compile");
     let input: String = "a".repeat(200);
-    run_with_timeout("polynomial_redos", move || {
-        // Intentionally no 'b' => matcher explores every way to partition
-        // the 'a's before failing. This is the worst case.
-        assert!(!re.is_match(&input));
-    });
+    let start = Instant::now();
+    // Intentionally no 'b' => matcher explores every way to partition
+    // the 'a's before failing. This is the worst case.
+    assert!(!re.is_match(&input));
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "polynomial ReDoS regression: 200-byte input took {:?}",
+        start.elapsed()
+    );
 }
 
 #[test]
@@ -561,12 +535,15 @@ fn xpath_double_slash_blowup() {
         xml.push_str(&format!("</l{}>", i));
     }
     xml.push_str("</r>");
-    // Move the owned String into the worker so &doc stays alive for 'static.
-    run_with_timeout("xpath_double_slash", move || {
-        let mut doc = parse(&xml).unwrap();
-        doc.prepare_xpath();
-        let eval = XPathEvaluator::new();
-        let root = doc.root();
-        let _ = eval.evaluate(&doc, root, "//*[//leaf]");
-    });
+    let mut doc = parse(&xml).unwrap();
+    doc.prepare_xpath();
+    let eval = XPathEvaluator::new();
+    let root = doc.root();
+    let start = Instant::now();
+    let _ = eval.evaluate(&doc, root, "//*[//leaf]");
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "XPath double-slash regression: query took {:?}",
+        start.elapsed()
+    );
 }

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -489,7 +489,7 @@ fn xpath_variable_reference_unsupported() {
 // ─── Finding F-15 — Namespace resolver lets `xml:` be rebound ───────────
 
 #[test]
-fn namespace_resolver_accepts_xml_rebinding() {
+fn namespace_resolver_refuses_xml_rebinding() {
     use std::borrow::Cow;
     use uppsala::NamespaceResolver;
     let mut r = NamespaceResolver::new();

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -80,12 +80,12 @@ fn quadratic_entity_expansion_bounded_accepted() {
 /// Regression for F-03. A deeply nested element chain previously recursed
 /// once per level in `parse_element` and could overflow the stack. The
 /// parser now enforces `DEFAULT_MAX_DEPTH` (128) and fails closed with a
-/// bounded error long before the stack is at risk — even for pathological
-/// million-deep input, which is rejected cheaply without ever recursing
-/// past the cap.
+/// bounded error long before the stack is at risk. A depth of 256 already
+/// exceeds the cap, so the parser rejects it well before reaching the
+/// bottom of the chain — no need to materialize a multi-megabyte string.
 #[test]
 fn deep_nesting_rejected_by_depth_cap() {
-    let depth = 1_000_000;
+    let depth = 256; // > DEFAULT_MAX_DEPTH (128)
     let mut xml = String::with_capacity(depth * 8);
     for _ in 0..depth {
         xml.push_str("<a>");
@@ -275,7 +275,7 @@ fn xpath_substring_overflow_handled() {
 // ─── Finding F-10 — XSD xs:include arbitrary local file read ────────────
 
 #[test]
-fn xsd_include_reads_absolute_paths() {
+fn xsd_include_rejects_absolute_paths() {
     // Regression test for F-10. Pre-fix the validator would
     // `fs::read_to_string` any attacker-supplied absolute
     // `schemaLocation` and merge its declarations in. Post-fix

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -63,6 +63,7 @@ fn billion_laughs_full() {
 /// silently" rather than OOM. Asserts the parser accepted the blow-up
 /// — which itself is the bug.
 #[test]
+#[ignore = "audit-only reproducer; default CI must not encode insecure behavior as expected"]
 fn billion_laughs_small_expands_unchecked() {
     let xml = r#"<?xml version="1.0"?>
 <!DOCTYPE lolz [
@@ -91,6 +92,7 @@ fn billion_laughs_small_expands_unchecked() {
 // ─── Finding F-02 — Quadratic entity expansion ──────────────────────────
 
 #[test]
+#[ignore = "audit-only reproducer; default CI must not encode insecure behavior as expected"]
 fn quadratic_entity_expansion_unchecked() {
     let xml = include_str!("../audit/pocs/quadratic_blowup.xml");
     let doc = parse(xml).expect("quadratic blow-up still parses today");

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -1,0 +1,570 @@
+//! Security-audit test harness.
+//!
+//! Each test reproduces a finding in SECURITY_AUDIT.md. Tests that exercise
+//! reliably-crashing bugs (stack overflow, billion-laughs OOM) are marked
+//! `#[ignore]` so the default `cargo test` run remains safe; invoke them
+//! explicitly with `cargo test --test security_audit -- --ignored`.
+//!
+//! Tests that time-bound a DoS use a worker thread plus a wall-clock
+//! timeout — if the worker doesn't finish within `TIMEOUT`, the test fails
+//! with "DoS: took > TIMEOUT".
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use uppsala::{parse, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
+
+// Wall-clock cap for DoS tests. Well under a typical cargo-test default.
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+fn run_with_timeout<F, R>(label: &'static str, f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let r = f();
+        let _ = tx.send(r);
+    });
+    match rx.recv_timeout(TIMEOUT) {
+        Ok(v) => v,
+        Err(_) => panic!(
+            "{}: exceeded {}s timeout (DoS confirmed)",
+            label,
+            TIMEOUT.as_secs()
+        ),
+    }
+}
+
+// ─── Finding F-01 — Billion Laughs (entity expansion) ──────────────────
+
+/// Canonical Billion Laughs. `&lol9;` expands to 10^9 characters.
+/// Must either be rejected *before* expansion (size cap / depth cap)
+/// or complete in bounded time. Current code fully expands it.
+#[test]
+#[ignore = "OOMs / hangs the test runner — run explicitly to confirm"]
+fn billion_laughs_full() {
+    let xml = include_str!("../audit/pocs/billion_laughs.xml");
+    let start = Instant::now();
+    let res = parse(xml);
+    let elapsed = start.elapsed();
+    assert!(
+        res.is_err() && elapsed < Duration::from_secs(1),
+        "expected billion-laughs rejection/limit; elapsed={:?}, err={:?}",
+        elapsed,
+        res.err()
+    );
+}
+
+/// CI-safe variant: 6-level nesting (~10^6 chars). Parser still fully
+/// expands but it fits in memory, so the failure mode is "completes
+/// silently" rather than OOM. Asserts the parser accepted the blow-up
+/// — which itself is the bug.
+#[test]
+fn billion_laughs_small_expands_unchecked() {
+    let xml = r#"<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+]>
+<lolz>&lol5;</lolz>"#;
+    let doc = parse(xml).expect("small billion-laughs still parses today");
+    let root = doc.document_element().unwrap();
+    let text = doc.text_content_deep(root);
+    // 3 * 10^5 chars — no entity-expansion cap was applied.
+    assert_eq!(
+        text.len(),
+        3 * 100_000,
+        "parser should have capped expansion; instead produced {} chars",
+        text.len()
+    );
+    // This test currently PASSES, which means the vulnerability is real.
+    // A fix should make this test FAIL (parser should reject / truncate).
+}
+
+// ─── Finding F-02 — Quadratic entity expansion ──────────────────────────
+
+#[test]
+fn quadratic_entity_expansion_unchecked() {
+    let xml = include_str!("../audit/pocs/quadratic_blowup.xml");
+    let doc = parse(xml).expect("quadratic blow-up still parses today");
+    let root = doc.document_element().unwrap();
+    let text_len = doc.text_content_deep(root).len();
+    // 20 chars × 10 (inner) × 10 (outer) = 2000 — small enough to run,
+    // but enforcement would reject or cap before expansion.
+    assert!(text_len >= 2000);
+}
+
+// ─── Finding F-03 — Parser stack overflow on deep nesting ───────────────
+
+/// Building a 1,000,000-deep element chain and feeding it to the parser
+/// aborts the process on Linux with an 8 MiB stack. We run it in a
+/// spawned thread with a small stack so the failure manifests as a
+/// thread-panic rather than crashing the test binary — but Rust still
+/// `abort()`s on stack overflow regardless of thread, so the whole
+/// binary will die. Marked `#[ignore]`.
+#[test]
+#[ignore = "stack overflow aborts the test binary; run explicitly"]
+fn deep_nesting_parser_stack_overflow() {
+    let depth = 1_000_000;
+    let mut xml = String::with_capacity(depth * 8);
+    for _ in 0..depth {
+        xml.push_str("<a>");
+    }
+    xml.push('x');
+    for _ in 0..depth {
+        xml.push_str("</a>");
+    }
+    let _ = parse(&xml);
+}
+
+/// Smaller, survivable variant — demonstrates that the parser accepts
+/// very deep nesting *without* any configured cap. The author can make
+/// this test fail by introducing a depth limit.
+#[test]
+#[ignore = "5k-deep nesting aborts the test binary on the default stack"]
+fn deep_nesting_accepted_without_cap() {
+    let depth = 5_000; // confirmed to stack-overflow on default 8 MiB stack
+    let mut xml = String::with_capacity(depth * 8);
+    for _ in 0..depth {
+        xml.push_str("<a>");
+    }
+    xml.push('x');
+    for _ in 0..depth {
+        xml.push_str("</a>");
+    }
+    let res = parse(&xml);
+    assert!(
+        res.is_ok(),
+        "expected current build to accept 5k-deep nesting (no cap enforced)"
+    );
+}
+
+// ─── Finding F-04 — XSD regex parser stack overflow on nested parens ────
+
+#[test]
+#[ignore = "stack overflow aborts the test binary; run explicitly"]
+fn xsd_regex_deep_paren_stack_overflow() {
+    let n = 50_000;
+    let mut pat = String::with_capacity(n * 2 + 1);
+    for _ in 0..n {
+        pat.push('(');
+    }
+    pat.push('a');
+    for _ in 0..n {
+        pat.push(')');
+    }
+    let _ = XsdRegex::compile(&pat);
+}
+
+// ─── Finding F-05 — Polynomial ReDoS in XSD regex ───────────────────────
+
+#[test]
+fn xsd_regex_polynomial_redos() {
+    // (a*)*b against N 'a's. Matcher is O(n^3)/O(n^4); at N=200
+    // it should finish quickly. If the dedup guard regresses, this
+    // will blow past TIMEOUT.
+    let re = XsdRegex::compile("(a*)*b").expect("compile");
+    let input: String = "a".repeat(200);
+    run_with_timeout("polynomial_redos", move || {
+        // Intentionally no 'b' => matcher explores every way to partition
+        // the 'a's before failing. This is the worst case.
+        assert!(!re.is_match(&input));
+    });
+}
+
+#[test]
+#[ignore = "demonstrates O(n^3+) blow-up; seconds of CPU at N=1000"]
+fn xsd_regex_polynomial_redos_heavy() {
+    let re = XsdRegex::compile("(a*)*b").unwrap();
+    let input: String = "a".repeat(1000);
+    let start = Instant::now();
+    let _ = re.is_match(&input);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "polynomial ReDoS: 1000-byte input took {:?}",
+        elapsed
+    );
+}
+
+// ─── Finding F-06 — XSD regex accepts unbounded {n,m} ───────────────────
+
+#[test]
+fn xsd_regex_unbounded_brace_accepted() {
+    // A schema may legitimately specify a large upper bound such as
+    // a{0,4_000_000_000}. Compile intentionally accepts it: the upper
+    // bound never drives allocation or a fixed iteration count. Matching
+    // is bounded instead by input saturation and the per-match step
+    // budget (ADR 0004, finding F-05), so a huge `m` cannot cause a
+    // time/memory blow-up. We therefore assert acceptance, and separately
+    // assert that matching such a pattern stays fast.
+    let re = XsdRegex::compile("a{0,4000000000}").expect("large bounds accepted");
+    let input: String = "a".repeat(10_000);
+    let start = Instant::now();
+    assert!(re.is_match(&input), "linear match should succeed");
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "huge upper bound must not slow matching (step budget bounds it)"
+    );
+}
+
+// ─── Finding F-07 — \p{unknown} silently matches nothing;
+//                   \P{unknown} matches everything (bypass) — FIXED ──────
+
+#[test]
+fn xsd_regex_unknown_prop_rejected() {
+    // Regression: an unknown Unicode property must be rejected at compile
+    // time (fail-closed). Previously `\P{unknown}` compiled and matched
+    // every character, silently widening an "only-letters" pattern into one
+    // that admits arbitrary markup. Both `\p{...}` and `\P{...}` forms, and
+    // the in-character-class form, must error.
+    assert!(
+        XsdRegex::compile("\\P{unknowncategory}+").is_err(),
+        "\\P{{unknown}} must fail to compile, not match everything"
+    );
+    assert!(
+        XsdRegex::compile("\\p{unknowncategory}+").is_err(),
+        "\\p{{unknown}} must fail to compile"
+    );
+    assert!(
+        XsdRegex::compile("[\\p{unknowncategory}]").is_err(),
+        "\\p{{unknown}} inside a character class must fail to compile"
+    );
+    // Known categories and blocks still compile.
+    assert!(XsdRegex::compile("\\p{Lu}+").is_ok());
+    assert!(XsdRegex::compile("\\p{IsBasicLatin}+").is_ok());
+}
+
+// ─── Finding F-08 — XPath parser stack overflow ─────────────────────────
+
+#[test]
+#[ignore = "stack overflow aborts the test binary; run explicitly"]
+fn xpath_parser_deep_paren_stack_overflow() {
+    let n = 20_000;
+    let mut expr = String::with_capacity(n * 2 + 1);
+    for _ in 0..n {
+        expr.push('(');
+    }
+    expr.push('1');
+    for _ in 0..n {
+        expr.push(')');
+    }
+    let mut doc = parse("<r/>").unwrap();
+    doc.prepare_xpath();
+    let eval = XPathEvaluator::new();
+    let root = doc.root();
+    let _ = eval.evaluate(&doc, root, &expr);
+}
+
+// ─── Finding F-09/F11 — XPath substring() overflow — FIXED ──────────────
+
+#[test]
+fn xpath_substring_overflow_handled() {
+    // Regression for F11. `substring(s, start, +inf)` coerced the length to
+    // `usize::MAX`; `start + len` then overflowed (debug panic / release wrap
+    // into an out-of-order slice). `substring` now uses `saturating_add` and
+    // clamps, so a huge/`inf` length yields a normal (clamped) result with no
+    // panic in either build profile.
+    use std::panic;
+    let mut doc = parse("<r>hello</r>").unwrap();
+    doc.prepare_xpath();
+    let eval = XPathEvaluator::new();
+    let root = doc.root();
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        eval.evaluate(&doc, root, "substring('hello', 2, 1 div 0)")
+    }));
+    assert!(result.is_ok(), "substring must not panic on overflow");
+    let value = result.unwrap().expect("evaluation succeeds");
+    // start=2 (1-based) with an unbounded length returns the rest of the string.
+    assert_eq!(value.to_string_value(&doc), "ello");
+}
+
+// ─── Finding F-10 — XSD xs:include arbitrary local file read ────────────
+
+#[test]
+fn xsd_include_reads_absolute_paths() {
+    // Regression test for F-10. Pre-fix the validator would
+    // `fs::read_to_string` any attacker-supplied absolute
+    // `schemaLocation` and merge its declarations in. Post-fix
+    // `resolve_include_path` rejects any resolved path that escapes the
+    // schema's base directory. We assert the validator build fails
+    // with the containment error.
+    let tmp_dir = std::env::temp_dir().join("uppsala-audit-canary");
+    std::fs::create_dir_all(&tmp_dir).unwrap();
+    let canary_path = tmp_dir.join("canary.xsd");
+    let canary_contents = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="leaked" type="xs:string"/>
+</xs:schema>"#;
+    std::fs::write(&canary_path, canary_contents).unwrap();
+
+    // The "untrusted" schema. schemaLocation is absolute — points
+    // outside the schema's own base directory.
+    let schema_dir = tmp_dir.join("schema-base");
+    std::fs::create_dir_all(&schema_dir).unwrap();
+    let schema_path = schema_dir.join("evil.xsd");
+    let schema_xml = format!(
+        r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="{}"/>
+  <xs:element name="x" type="xs:string"/>
+</xs:schema>"#,
+        canary_path.display()
+    );
+    std::fs::write(&schema_path, &schema_xml).unwrap();
+
+    let schema_doc = parse(&schema_xml).unwrap();
+    // Post-fix: the validator rejects the absolute schemaLocation
+    // because it escapes the schema's base directory. Any success
+    // here is a regression.
+    let result = XsdValidator::from_schema_with_base_path(&schema_doc, Some(&schema_path));
+    match result {
+        Ok(_) => panic!("absolute schemaLocation must be rejected (F-10 regression)"),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("escapes the schema's base directory"),
+                "expected containment error, got: {}",
+                msg
+            );
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+#[ignore = "stack overflow aborts the test binary; run explicitly"]
+fn xsd_include_circular_stack_overflow() {
+    let tmp = std::env::temp_dir().join("uppsala-audit-circular");
+    std::fs::create_dir_all(&tmp).unwrap();
+    let a = tmp.join("a.xsd");
+    let b = tmp.join("b.xsd");
+    std::fs::write(
+        &a,
+        r#"<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:include schemaLocation="b.xsd"/></xs:schema>"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &b,
+        r#"<?xml version="1.0"?><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:include schemaLocation="a.xsd"/></xs:schema>"#,
+    )
+    .unwrap();
+    let schema_src = std::fs::read_to_string(&a).unwrap();
+    let schema_doc = parse(&schema_src).unwrap();
+    let _ = XsdValidator::from_schema_with_base_path(&schema_doc, Some(&a));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ─── Finding F-11 — Round-trip injection via programmatic comment ──────
+
+#[test]
+fn roundtrip_comment_smuggle() {
+    // Regression test for F-13. Pre-fix, a `-->` sequence inside a
+    // comment body closed the comment early and let a subsequent
+    // `<injected/>` become a real sibling element. Post-fix,
+    // `sanitize_comment_content` pads consecutive dashes with a space
+    // so the terminator never appears in the output.
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[]);
+    w.comment("safe --> <injected/> <!--trailing");
+    w.end_element("r");
+    let out = w.into_string();
+    let reparsed = parse(&out).expect("sanitized output must reparse");
+    let root = reparsed.document_element().unwrap();
+    let children = reparsed.children(root);
+    let injected_elements: Vec<_> = children
+        .iter()
+        .filter(|c| matches!(reparsed.node_kind(**c), Some(uppsala::NodeKind::Element(_))))
+        .collect();
+    assert!(
+        injected_elements.is_empty(),
+        "comment smuggle leaked {} element child(ren) — sanitizer regressed: {:?}",
+        injected_elements.len(),
+        out
+    );
+}
+
+#[test]
+fn roundtrip_pi_smuggle() {
+    // Regression test for F-14. Pre-fix, a `?>` sequence inside PI
+    // data terminated the PI early. Post-fix, `sanitize_pi_data`
+    // inserts a space between `?` and `>` so the terminator scan
+    // cannot match.
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[]);
+    w.processing_instruction("x", Some("?><injected/>"));
+    w.end_element("r");
+    let out = w.into_string();
+    let reparsed = parse(&out).expect("sanitized output must reparse");
+    let root = reparsed.document_element().unwrap();
+    let children = reparsed.children(root);
+    let element_children: Vec<_> = children
+        .iter()
+        .filter(|c| matches!(reparsed.node_kind(**c), Some(uppsala::NodeKind::Element(_))))
+        .collect();
+    assert!(
+        element_children.is_empty(),
+        "PI smuggle leaked {} element child(ren) — sanitizer regressed: {:?}",
+        element_children.len(),
+        out
+    );
+}
+
+#[test]
+fn roundtrip_cdata_smuggle() {
+    // Regression test for F-15. Pre-fix, `]]>` inside CDATA content
+    // closed the section early and let `<injected/>` become a real
+    // sibling element. Post-fix, `split_cdata_content` replaces each
+    // `]]>` with the canonical `]]]]><![CDATA[>` split so the emitted
+    // output is two adjacent CDATA sections whose concatenation equals
+    // the original text.
+    let original = "safe]]><injected/>";
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[]);
+    w.cdata(original);
+    w.end_element("r");
+    let out = w.into_string();
+
+    let reparsed = parse(&out).expect("split CDATA must reparse");
+    let root = reparsed.document_element().unwrap();
+    let children = reparsed.children(root);
+    let element_children: Vec<_> = children
+        .iter()
+        .filter(|c| matches!(reparsed.node_kind(**c), Some(uppsala::NodeKind::Element(_))))
+        .collect();
+    assert!(
+        element_children.is_empty(),
+        "CDATA smuggle leaked {} element child(ren) — split regressed: {:?}",
+        element_children.len(),
+        out
+    );
+    // Text semantics must round-trip byte-exact (the CDATA split is
+    // byte-equivalent per XML 1.0, unlike comment/PI sanitization).
+    assert_eq!(
+        reparsed.text_content_deep(root),
+        original,
+        "CDATA split must preserve original text semantically"
+    );
+}
+
+// ─── Finding F-12 — UTF-16 decoder silently drops odd trailing byte — FIXED ─
+
+#[test]
+fn utf16_odd_byte_rejected() {
+    // Regression: a UTF-16 byte stream with an odd length has an incomplete
+    // trailing code unit. Previously the decoder's `chunks(2)` silently
+    // dropped the stray byte, hiding mid-code-unit truncation. The decoder
+    // now rejects odd-length input instead of fabricating a valid document.
+    let mut bytes = vec![0xFFu8, 0xFE]; // BOM LE
+    for c in "<r/>".chars() {
+        let cu = c as u16;
+        bytes.push(cu as u8);
+        bytes.push((cu >> 8) as u8);
+    }
+    bytes.push(0x41); // stray trailing byte → odd total length
+    let res = uppsala::parse_bytes(&bytes);
+    assert!(
+        res.is_err(),
+        "parser must error on incomplete UTF-16 tail, not silently drop it"
+    );
+}
+
+// ─── Finding F-13 — Pattern compile accepts arbitrary recursion in class subtraction ─
+
+#[test]
+#[ignore = "stack overflow on class-subtraction recursion"]
+fn xsd_regex_class_subtraction_stack() {
+    let n = 5_000;
+    let mut pat = String::new();
+    for _ in 0..n {
+        pat.push_str("[a-z-");
+    }
+    pat.push_str("[a-z]");
+    for _ in 0..n {
+        pat.push(']');
+    }
+    let _ = XsdRegex::compile(&pat);
+}
+
+// ─── Finding F-14 — XPath `$var` unsupported (low; documented as XPath 1.0) ──
+
+#[test]
+fn xpath_variable_reference_unsupported() {
+    let mut doc = parse("<r><a>1</a></r>").unwrap();
+    doc.prepare_xpath();
+    let eval = XPathEvaluator::new();
+    let root = doc.root();
+    let res = eval.evaluate(&doc, root, "$x");
+    assert!(
+        res.is_err(),
+        "XPath 1.0 variable reference is not implemented — library documents support for XPath 1.0"
+    );
+}
+
+// ─── Finding F-15 — Namespace resolver lets `xml:` be rebound ───────────
+
+#[test]
+fn namespace_resolver_accepts_xml_rebinding() {
+    use std::borrow::Cow;
+    use uppsala::NamespaceResolver;
+    let mut r = NamespaceResolver::new();
+    r.declare(Cow::Borrowed("xml"), Cow::Borrowed("urn:evil"));
+    let uri = r.resolve("xml").map(|c| c.as_ref().to_string());
+    // Per XML Namespaces §3 rebinding "xml" should be refused.
+    assert_ne!(
+        uri.as_deref(),
+        Some("urn:evil"),
+        "resolver permitted rebinding the reserved prefix `xml`"
+    );
+}
+
+// ─── Finding F-16 — Control characters silently emitted on serialize — FIXED ─
+
+#[test]
+fn control_char_sanitized_on_attribute_write() {
+    // Construct an attribute value containing U+0001 (an illegal Char
+    // in XML 1.0) and serialize. The writer now replaces invalid XML
+    // characters with U+FFFD so the output remains parseable.
+    let mut w = XmlWriter::new();
+    w.start_element("r", &[("a", "x\u{0001}y")]);
+    w.end_element("r");
+    let out = w.into_string();
+    assert!(!out.contains('\u{0001}'));
+    assert!(out.contains('\u{FFFD}'));
+    parse(&out).expect("sanitized output must reparse");
+}
+
+// ─── Finding F-17 — XPath //a//b//c cross-product blow-up ──────────────
+
+#[test]
+fn xpath_double_slash_blowup() {
+    // Build a modestly large tree and time a predicate-in-predicate
+    // query. 50 levels × 20 siblings.
+    let mut xml = String::from("<r>");
+    for i in 0..50 {
+        xml.push_str(&format!("<l{}>", i));
+    }
+    for _ in 0..20 {
+        xml.push_str("<leaf/>");
+    }
+    for i in (0..50).rev() {
+        xml.push_str(&format!("</l{}>", i));
+    }
+    xml.push_str("</r>");
+    // Move the owned String into the worker so &doc stays alive for 'static.
+    run_with_timeout("xpath_double_slash", move || {
+        let mut doc = parse(&xml).unwrap();
+        doc.prepare_xpath();
+        let eval = XPathEvaluator::new();
+        let root = doc.root();
+        let _ = eval.evaluate(&doc, root, "//*[//leaf]");
+    });
+}

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -13,7 +13,8 @@ use uppsala::{parse, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
 
 /// Canonical Billion Laughs. `&lol9;` expands to 10^9 characters.
 /// Must either be rejected *before* expansion (size cap / depth cap)
-/// or complete in bounded time. Current code fully expands it.
+/// or complete in bounded time. The assertion below pins the hardened
+/// behavior: parsing fails closed in well under a second.
 #[test]
 #[ignore = "OOMs / hangs the test runner — run explicitly to confirm"]
 fn billion_laughs_full() {

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -1,9 +1,13 @@
 //! Security-audit test harness.
 //!
-//! Each test reproduces a finding in SECURITY_AUDIT.md. Tests that exercise
-//! reliably-crashing bugs (stack overflow, billion-laughs OOM) are marked
-//! `#[ignore]` so the default `cargo test` run remains safe; invoke them
-//! explicitly with `cargo test --test security_audit -- --ignored`.
+//! Each test reproduces a finding in SECURITY_AUDIT.md, using the finding's
+//! canonical `F-NN` identifier. Findings that are now fixed assert the
+//! hardened behavior (fail-closed error, bounded time, or a still-working
+//! legitimate baseline). A few reproducers that can only manifest as a
+//! process-fatal crash on the *unhardened* code path (e.g. a true stack
+//! overflow) remain `#[ignore]` so the default `cargo test` run stays safe;
+//! invoke them explicitly with
+//! `cargo test --test security_audit -- --ignored`.
 //!
 use std::time::{Duration, Instant};
 
@@ -30,13 +34,14 @@ fn billion_laughs_full() {
     );
 }
 
-/// CI-safe variant: 6-level nesting (~10^6 chars). Parser still fully
-/// expands but it fits in memory, so the failure mode is "completes
-/// silently" rather than OOM. Asserts the parser accepted the blow-up
-/// — which itself is the bug.
+/// Bounded-expansion baseline: 5-level nesting expands to ~3×10^5 chars,
+/// which is *below* the default entity-expansion byte budget
+/// (`DEFAULT_MAX_ENTITY_EXPANSION`, 1 MiB). Such a document is legitimate
+/// and must still parse — the cap fails closed only on the unbounded
+/// blow-up (`billion_laughs_full`), not on bounded expansion. This pins
+/// that the cap does not over-reject below its threshold.
 #[test]
-#[ignore = "audit-only reproducer; default CI must not encode insecure behavior as expected"]
-fn billion_laughs_small_expands_unchecked() {
+fn bounded_entity_expansion_within_cap_accepted() {
     let xml = r#"<?xml version="1.0"?>
 <!DOCTYPE lolz [
   <!ENTITY lol "lol">
@@ -47,45 +52,39 @@ fn billion_laughs_small_expands_unchecked() {
   <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
 ]>
 <lolz>&lol5;</lolz>"#;
-    let doc = parse(xml).expect("small billion-laughs still parses today");
+    let doc = parse(xml).expect("bounded expansion below the cap must still parse");
     let root = doc.document_element().unwrap();
     let text = doc.text_content_deep(root);
-    // 3 * 10^5 chars — no entity-expansion cap was applied.
-    assert_eq!(
-        text.len(),
-        3 * 100_000,
-        "parser should have capped expansion; instead produced {} chars",
-        text.len()
-    );
-    // This test currently PASSES, which means the vulnerability is real.
-    // A fix should make this test FAIL (parser should reject / truncate).
+    // 3 × 10^5 chars — well under the 1 MiB expansion budget.
+    assert_eq!(text.len(), 3 * 100_000);
 }
 
-// ─── Finding F-02 — Quadratic entity expansion ──────────────────────────
+// ─── Finding F-02 — Quadratic entity expansion (bounded baseline) ───────
 
+/// The quadratic POC expands to ~2000 chars, far below the expansion byte
+/// budget, so it parses. This is the "legitimate bounded input still
+/// works" control for F-02; the unbounded blow-up is bounded by
+/// `DEFAULT_MAX_ENTITY_EXPANSION` and `DEFAULT_MAX_ENTITY_DEPTH`.
 #[test]
-#[ignore = "audit-only reproducer; default CI must not encode insecure behavior as expected"]
-fn quadratic_entity_expansion_unchecked() {
+fn quadratic_entity_expansion_bounded_accepted() {
     let xml = include_str!("../audit/pocs/quadratic_blowup.xml");
-    let doc = parse(xml).expect("quadratic blow-up still parses today");
+    let doc = parse(xml).expect("bounded quadratic expansion still parses");
     let root = doc.document_element().unwrap();
     let text_len = doc.text_content_deep(root).len();
-    // 20 chars × 10 (inner) × 10 (outer) = 2000 — small enough to run,
-    // but enforcement would reject or cap before expansion.
+    // 20 chars × 10 (inner) × 10 (outer) = 2000 — below the expansion cap.
     assert!(text_len >= 2000);
 }
 
-// ─── Finding F-03 — Parser stack overflow on deep nesting ───────────────
+// ─── Finding F-03 — Parser deep-nesting depth cap — FIXED ───────────────
 
-/// Building a 1,000,000-deep element chain and feeding it to the parser
-/// aborts the process on Linux with an 8 MiB stack. We run it in a
-/// spawned thread with a small stack so the failure manifests as a
-/// thread-panic rather than crashing the test binary — but Rust still
-/// `abort()`s on stack overflow regardless of thread, so the whole
-/// binary will die. Marked `#[ignore]`.
+/// Regression for F-03. A deeply nested element chain previously recursed
+/// once per level in `parse_element` and could overflow the stack. The
+/// parser now enforces `DEFAULT_MAX_DEPTH` (128) and fails closed with a
+/// bounded error long before the stack is at risk — even for pathological
+/// million-deep input, which is rejected cheaply without ever recursing
+/// past the cap.
 #[test]
-#[ignore = "stack overflow aborts the test binary; run explicitly"]
-fn deep_nesting_parser_stack_overflow() {
+fn deep_nesting_rejected_by_depth_cap() {
     let depth = 1_000_000;
     let mut xml = String::with_capacity(depth * 8);
     for _ in 0..depth {
@@ -95,16 +94,25 @@ fn deep_nesting_parser_stack_overflow() {
     for _ in 0..depth {
         xml.push_str("</a>");
     }
-    let _ = parse(&xml);
+    let res = parse(&xml);
+    assert!(
+        res.is_err(),
+        "deep nesting must be rejected by the depth cap, not stack-overflow"
+    );
+    let msg = format!("{:?}", res.err());
+    assert!(
+        msg.contains("nesting exceeds maximum depth"),
+        "expected depth-cap error, got: {}",
+        msg
+    );
 }
 
-/// Smaller, survivable variant — demonstrates that the parser accepts
-/// very deep nesting *without* any configured cap. The author can make
-/// this test fail by introducing a depth limit.
+/// Control: nesting that stays within the default cap still parses. This
+/// pins the boundary so a future cap change that breaks legitimate
+/// moderately-nested documents is caught.
 #[test]
-#[ignore = "5k-deep nesting aborts the test binary on the default stack"]
-fn deep_nesting_accepted_without_cap() {
-    let depth = 5_000; // confirmed to stack-overflow on default 8 MiB stack
+fn moderate_nesting_within_cap_accepted() {
+    let depth = 100; // < DEFAULT_MAX_DEPTH (128)
     let mut xml = String::with_capacity(depth * 8);
     for _ in 0..depth {
         xml.push_str("<a>");
@@ -116,7 +124,8 @@ fn deep_nesting_accepted_without_cap() {
     let res = parse(&xml);
     assert!(
         res.is_ok(),
-        "expected current build to accept 5k-deep nesting (no cap enforced)"
+        "nesting within the default depth cap must still parse: {:?}",
+        res.err()
     );
 }
 
@@ -240,11 +249,11 @@ fn xpath_parser_deep_paren_stack_overflow() {
     let _ = eval.evaluate(&doc, root, &expr);
 }
 
-// ─── Finding F-09/F11 — XPath substring() overflow — FIXED ──────────────
+// ─── Finding F-09 — XPath substring() overflow — FIXED ──────────────────
 
 #[test]
 fn xpath_substring_overflow_handled() {
-    // Regression for F11. `substring(s, start, +inf)` coerced the length to
+    // Regression for F-09. `substring(s, start, +inf)` coerced the length to
     // `usize::MAX`; `start + len` then overflowed (debug panic / release wrap
     // into an out-of-order slice). `substring` now uses `saturating_add` and
     // clamps, so a huge/`inf` length yields a normal (clamped) result with no
@@ -317,9 +326,15 @@ fn xsd_include_reads_absolute_paths() {
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }
 
+// ─── Finding F-11 — Circular xs:include cycle cap — FIXED ───────────────
+
+/// Regression for F-11. `a.xsd` includes `b.xsd`, which includes `a.xsd`.
+/// Pre-fix the loader recursed through the cycle until the stack
+/// overflowed. The composition pass now carries a visited-paths set and a
+/// depth cap, so the cycle is short-circuited and the build completes in
+/// bounded time without overflowing.
 #[test]
-#[ignore = "stack overflow aborts the test binary; run explicitly"]
-fn xsd_include_circular_stack_overflow() {
+fn xsd_include_circular_handled() {
     let tmp = std::env::temp_dir().join("uppsala-audit-circular");
     std::fs::create_dir_all(&tmp).unwrap();
     let a = tmp.join("a.xsd");
@@ -336,6 +351,9 @@ fn xsd_include_circular_stack_overflow() {
     .unwrap();
     let schema_src = std::fs::read_to_string(&a).unwrap();
     let schema_doc = parse(&schema_src).unwrap();
+    // Must return (cycle detected / short-circuited), not recurse forever
+    // or overflow the stack. Either Ok or a bounded Err is acceptable;
+    // the point is that it terminates.
     let _ = XsdValidator::from_schema_with_base_path(&schema_doc, Some(&a));
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -432,7 +450,7 @@ fn roundtrip_cdata_smuggle() {
     );
 }
 
-// ─── Finding F-12 — UTF-16 decoder silently drops odd trailing byte — FIXED ─
+// ─── Finding F-20 — UTF-16 decoder silently drops odd trailing byte — FIXED ─
 
 #[test]
 fn utf16_odd_byte_rejected() {
@@ -454,7 +472,7 @@ fn utf16_odd_byte_rejected() {
     );
 }
 
-// ─── Finding F-13 — Pattern compile accepts arbitrary recursion in class subtraction ─
+// ─── Finding F-04 — XSD regex compiler stack overflow (class-subtraction recursion) ─
 
 #[test]
 #[ignore = "stack overflow on class-subtraction recursion"]
@@ -471,7 +489,7 @@ fn xsd_regex_class_subtraction_stack() {
     let _ = XsdRegex::compile(&pat);
 }
 
-// ─── Finding F-14 — XPath `$var` unsupported (low; documented as XPath 1.0) ──
+// ─── Finding F-24 — XPath `$var` unsupported (low; documented as XPath 1.0) ──
 
 #[test]
 fn xpath_variable_reference_unsupported() {
@@ -486,7 +504,7 @@ fn xpath_variable_reference_unsupported() {
     );
 }
 
-// ─── Finding F-15 — Namespace resolver lets `xml:` be rebound ───────────
+// ─── Finding F-19 — Namespace resolver lets `xml:` be rebound ───────────
 
 #[test]
 fn namespace_resolver_refuses_xml_rebinding() {
@@ -503,7 +521,7 @@ fn namespace_resolver_refuses_xml_rebinding() {
     );
 }
 
-// ─── Finding F-16 — Control characters silently emitted on serialize — FIXED ─
+// ─── Finding F-18 — Control characters silently emitted on serialize — FIXED ─
 
 #[test]
 fn control_char_sanitized_on_attribute_write() {
@@ -519,7 +537,7 @@ fn control_char_sanitized_on_attribute_write() {
     parse(&out).expect("sanitized output must reparse");
 }
 
-// ─── Finding F-17 — XPath //a//b//c cross-product blow-up ──────────────
+// ─── Finding F-21 — XPath //a//b//c cross-product blow-up ──────────────
 
 #[test]
 fn xpath_double_slash_blowup() {

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -340,7 +340,7 @@ fn xsd_include_circular_stack_overflow() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-// ─── Finding F-11 — Round-trip injection via programmatic comment ──────
+// ─── Finding F-13 — Round-trip injection via programmatic comment ──────
 
 #[test]
 fn roundtrip_comment_smuggle() {

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -254,6 +254,34 @@ fn xpath_id_function_scan_is_budgeted() {
 }
 
 #[test]
+fn xpath_descendant_collection_handles_deep_programmatic_dom() {
+    // Programmatic DOM construction can exceed parser depth caps. Descendant
+    // axes must use heap-backed traversal so a deep chain is still budgeted.
+    let mut doc = Document::new();
+    let mut parent = doc.root();
+    for _ in 0..4096 {
+        let child = doc.create_element(QName::local("n"));
+        doc.append_child(parent, child);
+        parent = child;
+    }
+    let leaf = doc.create_element(QName::local("leaf"));
+    doc.append_child(parent, leaf);
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(20_000)
+        .select_nodes(&doc, doc.root(), "//leaf")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0], leaf);
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(32)
+        .select_nodes(&doc, doc.root(), "//leaf")
+        .expect_err("deep descendant traversal must remain budgeted");
+    assert!(err.to_string().contains("maximum node visit budget of 32"));
+}
+
+#[test]
 fn serializers_replace_invalid_xml_characters() {
     let mut writer = XmlWriter::new();
     writer.start_element("r", &[("a", "x\u{0001}y")]);

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -254,6 +254,36 @@ fn xpath_id_function_scan_is_budgeted() {
 }
 
 #[test]
+fn xpath_id_function_handles_deep_programmatic_dom() {
+    // id() scans the whole document. It must use heap-backed traversal too,
+    // because callers can build deeper DOMs than the parser accepts.
+    let mut doc = Document::new();
+    let mut parent = doc.root();
+    for _ in 0..4096 {
+        let child = doc.create_element(QName::local("n"));
+        doc.append_child(parent, child);
+        parent = child;
+    }
+    let leaf = doc.create_element(QName::local("leaf"));
+    doc.element_mut(leaf)
+        .unwrap()
+        .set_attribute(QName::local("id"), Cow::Borrowed("target"));
+    doc.append_child(parent, leaf);
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(10_000)
+        .select_nodes(&doc, doc.root(), "id('target')")
+        .unwrap();
+    assert_eq!(nodes, vec![leaf]);
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(32)
+        .select_nodes(&doc, doc.root(), "id('target')")
+        .expect_err("deep id() traversal must remain budgeted");
+    assert!(err.to_string().contains("maximum node visit budget of 32"));
+}
+
+#[test]
 fn xpath_descendant_collection_handles_deep_programmatic_dom() {
     // Programmatic DOM construction can exceed parser depth caps. Descendant
     // axes must use heap-backed traversal so a deep chain is still budgeted.

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -276,6 +276,27 @@ fn xpath_axis_budget_is_not_double_charged_after_name_test() {
 }
 
 #[test]
+fn xpath_predicate_budget_charges_candidates_once() {
+    // Predicate filtering visits each candidate once. Kept nodes are a subset
+    // of those candidates and must not be charged a second time.
+    let doc = parse("<r><a/><b/></r>").unwrap();
+    let root = doc.document_element().unwrap();
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(4)
+        .select_nodes(&doc, root, "*[1]")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(doc.element(nodes[0]).unwrap().name.local_name, "a");
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(3)
+        .select_nodes(&doc, root, "*[1]")
+        .expect_err("predicate candidates must still be budgeted");
+    assert!(err.to_string().contains("maximum node visit budget of 3"));
+}
+
+#[test]
 fn xpath_id_function_scan_is_budgeted() {
     // id() performs a document-wide lookup. It must consume the same visit
     // budget as axis expansion so callers can bound adversarial lookups.
@@ -693,6 +714,61 @@ fn xsd_keyref_field_uses_local_namespace_scope() {
     assert!(
         errors.iter().any(|e| e.contains("no matching key value")),
         "expected field-local namespace to expose bad keyref, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_identity_selector_handles_deep_programmatic_dom() {
+    // `.//` identity-constraint selectors must use heap-backed traversal just
+    // like XPath axes, because callers can construct deeper DOMs than the
+    // parser accepts.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:v="urn:v"
+           targetNamespace="urn:v"
+           elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="##any" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="leaf_ids">
+      <xs:selector xpath=".//v:leaf"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+  </xs:element>
+</xs:schema>"###;
+    let schema_doc = parse(schema).unwrap();
+    let validator = XsdValidator::from_schema(&schema_doc).unwrap();
+
+    let mut doc = Document::new();
+    let doc_root = doc.root();
+    let root = doc.create_element(QName::full("v", "urn:v", "root"));
+    doc.append_child(doc_root, root);
+
+    let mut parent = root;
+    for _ in 0..4096 {
+        let child = doc.create_element(QName::full("v", "urn:v", "n"));
+        doc.append_child(parent, child);
+        parent = child;
+    }
+
+    let first = doc.create_element(QName::full("v", "urn:v", "leaf"));
+    doc.element_mut(first)
+        .unwrap()
+        .set_attribute(QName::local("id"), Cow::Borrowed("same"));
+    doc.append_child(parent, first);
+
+    let second = doc.create_element(QName::full("v", "urn:v", "leaf"));
+    doc.element_mut(second)
+        .unwrap()
+        .set_attribute(QName::local("id"), Cow::Borrowed("same"));
+    doc.append_child(parent, second);
+
+    let errors = validator.validate(&doc);
+    assert!(
+        errors.iter().any(|e| e.message.contains("duplicate value")),
+        "expected deep identity selector to find duplicate key, got {errors:?}"
     );
 }
 

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -703,6 +703,39 @@ fn xsd_attribute_wildcard_union_stays_namespace_precise() {
 }
 
 #[test]
+fn xsd_attribute_wildcard_union_other_plus_local_excludes_target() {
+    // ##other excludes both the schema target namespace and local attributes;
+    // unioning it with ##local should add local attributes without admitting
+    // target-namespace attributes.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:complexType name="Base">
+    <xs:anyAttribute namespace="##other" processContents="skip"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:extension base="t:Base">
+        <xs:anyAttribute namespace="##local" processContents="skip"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="r" type="t:Derived"/>
+</xs:schema>"###;
+
+    let valid = r#"<t:r xmlns:t="urn:t" xmlns:f="urn:f" local="ok" f:foreign="ok"/>"#;
+    assert!(validate(schema, valid).is_empty());
+
+    let invalid = r#"<t:r xmlns:t="urn:t" t:target="no"/>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("not allowed by wildcard")),
+        "expected target-namespace wildcard error, got {errors:?}"
+    );
+}
+
+#[test]
 fn xsd_complex_type_derivation_cycles_are_rejected() {
     // Recursive complex-type derivation can otherwise loop while resolving the
     // effective content model. The validator should detect the cycle and report

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -1,0 +1,460 @@
+//! Security regression coverage for hardening shipped in the 0.5.0 cycle.
+//!
+//! These tests intentionally favor small, hand-written inputs over large
+//! conformance fixtures. Each case captures a previously risky behavior and
+//! documents the fail-closed outcome expected from the public API.
+
+use std::borrow::Cow;
+use std::fs;
+use std::path::PathBuf;
+
+use uppsala::{parse, Document, NodeId, QName, XPathEvaluator, XmlWriter, XsdValidator};
+
+fn validate(schema: &str, instance: &str) -> Vec<String> {
+    // Keep XSD assertions compact by returning display strings rather than
+    // leaking validator internals into each test.
+    let schema_doc = parse(schema).expect("parse schema");
+    let validator = XsdValidator::from_schema(&schema_doc).expect("build validator");
+    let doc = parse(instance).expect("parse instance");
+    validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect()
+}
+
+fn mkdir_unique(label: &str) -> PathBuf {
+    // XSD import/include tests need a real base path; use a process-unique
+    // directory so parallel test runs do not collide.
+    let dir = std::env::temp_dir().join(format!(
+        "uppsala-security-{}-{}-{}",
+        label,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+#[test]
+fn parser_rejects_duplicate_expanded_attributes() {
+    // Namespace-aware XML forbids duplicate attributes after expansion, even
+    // when the lexical prefixes differ. Accepting both would let the same
+    // logical attribute carry conflicting values.
+    let err = parse(r#"<r xmlns:a="urn:x" xmlns:b="urn:x" a:id="first" b:id="second"/>"#)
+        .expect_err("duplicate expanded attributes must be rejected");
+    assert!(err.to_string().contains("Duplicate attribute"));
+}
+
+#[test]
+fn writer_sanitizes_structural_names() {
+    // Programmatic writer callers can pass arbitrary strings as element and
+    // attribute names. Invalid structural names are collapsed to a safe QName
+    // instead of being emitted verbatim into markup position.
+    let mut writer = XmlWriter::new();
+    writer.start_element("bad name", &[("bad attr", "value")]);
+    writer.end_element("bad name");
+    let output = writer.into_string();
+
+    assert_eq!(output, r#"<_ _="value"></_>"#);
+    parse(&output).expect("sanitized writer output must reparse");
+}
+
+#[test]
+fn writer_disambiguates_sanitized_attribute_collisions() {
+    // Distinct invalid names can sanitize to the same fallback `_`. The writer
+    // must make later names unique so the output remains well-formed XML.
+    let mut writer = XmlWriter::new();
+    writer.start_element(
+        "r",
+        &[("bad attr", "one"), ("bad\tattr", "two"), ("_", "three")],
+    );
+    writer.end_element("r");
+    let output = writer.into_string();
+
+    assert_eq!(output, r#"<r _="one" __1="two" __2="three"></r>"#);
+    parse(&output).expect("collision-disambiguated writer output must reparse");
+}
+
+#[test]
+fn dom_serializer_sanitizes_programmatic_names() {
+    // The DOM path has the same structural-name threat model as XmlWriter:
+    // names constructed in memory must not be able to break serialized XML.
+    let mut doc = Document::new();
+    let root = doc.root();
+    let elem = doc.create_element(QName::local("bad name"));
+    doc.append_child(root, elem);
+    doc.element_mut(elem)
+        .unwrap()
+        .set_attribute(QName::local("bad attr"), Cow::Borrowed("value"));
+
+    let output = doc.to_xml();
+    assert_eq!(output, r#"<_ _="value"/>"#);
+    parse(&output).expect("sanitized DOM output must reparse");
+}
+
+#[test]
+fn dom_serializer_disambiguates_sanitized_attribute_collisions() {
+    // DOM serialization also needs collision handling after sanitization,
+    // because programmatic attributes can contain arbitrary invalid QNames.
+    let mut doc = Document::new();
+    let root = doc.root();
+    let elem = doc.create_element(QName::local("r"));
+    doc.append_child(root, elem);
+    let elem = doc.element_mut(elem).unwrap();
+    elem.set_attribute(QName::local("bad attr"), Cow::Borrowed("one"));
+    elem.set_attribute(QName::local("bad\tattr"), Cow::Borrowed("two"));
+    elem.set_attribute(QName::local("_"), Cow::Borrowed("three"));
+
+    let output = doc.to_xml();
+    assert_eq!(output, r#"<r _="one" __1="two" __2="three"/>"#);
+    parse(&output).expect("collision-disambiguated DOM output must reparse");
+}
+
+#[test]
+fn parse_bytes_rejects_odd_utf16_tail() {
+    // A UTF-16 byte stream is a sequence of 16-bit code units. A trailing
+    // orphan byte means the input is truncated and must not be silently
+    // discarded by the decoder.
+    let mut le = vec![0xFF, 0xFE];
+    for code_unit in "<r/>".encode_utf16() {
+        le.extend_from_slice(&code_unit.to_le_bytes());
+    }
+    le.push(0x41);
+    assert!(uppsala::parse_bytes(&le).is_err());
+
+    let mut be = vec![0xFE, 0xFF];
+    for code_unit in "<r/>".encode_utf16() {
+        be.extend_from_slice(&code_unit.to_be_bytes());
+    }
+    be.push(0x41);
+    assert!(uppsala::parse_bytes(&be).is_err());
+}
+
+#[test]
+fn doctype_is_omitted_unless_explicitly_requested() {
+    // Parsed DOCTYPE declarations are preserved for callers that need them,
+    // but serialization omits them by default to avoid handing DTDs to
+    // downstream processors unintentionally.
+    let xml = r#"<?xml version="1.0"?><!DOCTYPE root SYSTEM "root.dtd"><root/>"#;
+    let doc = parse(xml).unwrap();
+
+    assert_eq!(doc.to_xml(), r#"<?xml version="1.0"?><root/>"#);
+    let opts = uppsala::XmlWriteOptions::compact().with_doctype(true);
+    assert_eq!(doc.to_xml_with_options(&opts), xml);
+}
+
+#[test]
+fn dom_mutation_rejects_invalid_and_cyclic_node_ids() {
+    // Public mutation APIs accept NodeId values, so they must ignore invalid
+    // IDs and ancestry cycles instead of corrupting the arena links.
+    let mut doc = Document::new();
+    let root = doc.root();
+    let a = doc.create_element(QName::local("a"));
+    let b = doc.create_element(QName::local("b"));
+    doc.append_child(root, a);
+    doc.append_child(a, b);
+
+    doc.append_child(b, a);
+    assert_eq!(doc.parent(a), Some(root));
+    assert_eq!(doc.parent(b), Some(a));
+
+    doc.append_child(NodeId::new(99_999), a);
+    doc.insert_before(root, NodeId::new(88_888), a);
+    doc.replace_child(root, NodeId::new(77_777), a);
+
+    assert_eq!(doc.parent(a), Some(root));
+    assert_eq!(doc.children(root), vec![a]);
+}
+
+#[test]
+fn xpath_name_tests_are_namespace_aware() {
+    // XPath prefixes are expression bindings, not document prefix text. This
+    // verifies unprefixed tests match only no-namespace nodes and unbound
+    // prefixes fail closed.
+    let doc = parse(r#"<r xmlns:a="urn:a"><a:item/><item/></r>"#).unwrap();
+    let root = doc.document_element().unwrap();
+
+    let eval = XPathEvaluator::new();
+    let unprefixed = eval.select_nodes(&doc, root, "item").unwrap();
+    assert_eq!(unprefixed.len(), 1);
+    assert!(doc
+        .element(unprefixed[0])
+        .unwrap()
+        .name
+        .namespace_uri
+        .is_none());
+
+    let unbound = eval.select_nodes(&doc, root, "a:item").unwrap();
+    assert!(unbound.is_empty());
+
+    let mut bound = XPathEvaluator::new();
+    bound.add_namespace("a", "urn:a");
+    let prefixed = bound.select_nodes(&doc, root, "a:item").unwrap();
+    assert_eq!(prefixed.len(), 1);
+    assert_eq!(
+        doc.element(prefixed[0])
+            .unwrap()
+            .name
+            .namespace_uri
+            .as_deref(),
+        Some("urn:a")
+    );
+}
+
+#[test]
+fn xpath_axis_expansion_is_budgeted() {
+    // Descendant-style axes can expand over the entire DOM. A low visit budget
+    // must stop expansion with a stable diagnostic, while a normal budget still
+    // returns the expected nodes.
+    let xml = "<r><a><b/><b/><b/><b/></a></r>";
+    let doc = parse(xml).unwrap();
+    let root = doc.root();
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(2)
+        .select_nodes(&doc, root, "//b")
+        .expect_err("low node visit budget must stop expansion");
+    assert!(err.to_string().contains("maximum node visit budget of 2"));
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(100)
+        .select_nodes(&doc, root, "//b")
+        .unwrap();
+    assert_eq!(nodes.len(), 4);
+}
+
+#[test]
+fn serializers_replace_invalid_xml_characters() {
+    let mut writer = XmlWriter::new();
+    writer.start_element("r", &[("a", "x\u{0001}y")]);
+    writer.text("t\u{0000}u");
+    writer.comment("c\u{0008}d");
+    writer.processing_instruction("p", Some("q\u{000C}r"));
+    writer.cdata("z\u{000B}w");
+    writer.end_element("r");
+    let xml = writer.into_string();
+
+    assert!(!xml.contains('\u{0000}'));
+    assert!(!xml.contains('\u{0001}'));
+    assert!(!xml.contains('\u{0008}'));
+    assert!(!xml.contains('\u{000B}'));
+    assert!(!xml.contains('\u{000C}'));
+    assert!(xml.contains('\u{FFFD}'));
+    parse(&xml).expect("sanitized writer output must reparse");
+
+    let mut doc = Document::new();
+    let root = doc.root();
+    let elem = doc.create_element(QName::local("r"));
+    doc.append_child(root, elem);
+    doc.element_mut(elem)
+        .unwrap()
+        .set_attribute(QName::local("a"), Cow::Borrowed("x\u{0001}y"));
+    let text = doc.create_text("t\u{0000}u");
+    doc.append_child(elem, text);
+    let output = doc.to_xml();
+
+    assert!(!output.contains('\u{0000}'));
+    assert!(!output.contains('\u{0001}'));
+    assert!(output.contains('\u{FFFD}'));
+    parse(&output).expect("sanitized DOM output must reparse");
+}
+
+#[test]
+fn xsd_rejects_malformed_time_and_datetime_values() {
+    // Timezone parsing must reject invalid offsets and malformed Unicode input
+    // as validation errors. The non-ASCII cases exercise byte-boundary safety.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="t" type="xs:time"/>
+  <xs:element name="dt" type="xs:dateTime"/>
+</xs:schema>"#;
+
+    assert!(validate(schema, "<t>23:59:59Z</t>").is_empty());
+    assert!(!validate(schema, "<t>12:00:00:99</t>").is_empty());
+    assert!(!validate(schema, "<t>12:00:00+99:00</t>").is_empty());
+    assert!(!validate(schema, "<t>24:00:01</t>").is_empty());
+    assert!(!validate(schema, "<t>12:00:0é0+000</t>").is_empty());
+    assert!(!validate(schema, "<dt>2024-01-01T12:00:00+99:00</dt>").is_empty());
+    assert!(!validate(schema, "<dt>2024-01-01T12:00:0é0+000</dt>").is_empty());
+}
+
+#[test]
+fn namespaced_root_does_not_fall_back_to_no_namespace_declaration() {
+    // A no-namespace declaration must not validate a namespaced document root.
+    // Falling back by local name would accept documents outside the schema's
+    // declared namespace.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:string"/>
+</xs:schema>"#;
+
+    let errors = validate(schema, r#"<x:root xmlns:x="urn:x">ok</x:root>"#);
+    assert!(
+        errors.iter().any(|e| e.contains("No element declaration")),
+        "expected no-declaration error, got {errors:?}"
+    );
+}
+
+#[test]
+fn prefixed_xsd_type_qnames_resolve_to_imported_namespace() {
+    // Prefixed `type` QNames in schemas are resolved through in-scope namespace
+    // declarations. This keeps imported types precise and prevents local-name
+    // fallback from masking invalid values.
+    let dir = mkdir_unique("prefixed-type");
+
+    let inner = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:inner">
+  <xs:simpleType name="Code">
+    <xs:restriction base="xs:int"/>
+  </xs:simpleType>
+</xs:schema>"#;
+    fs::write(dir.join("inner.xsd"), inner).unwrap();
+
+    let outer = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:i="urn:inner"
+           xmlns:o="urn:outer"
+           targetNamespace="urn:outer"
+           elementFormDefault="qualified">
+  <xs:import namespace="urn:inner" schemaLocation="inner.xsd"/>
+  <xs:element name="item" type="i:Code"/>
+</xs:schema>"#;
+    let outer_path = dir.join("outer.xsd");
+    fs::write(&outer_path, outer).unwrap();
+
+    let schema_doc = parse(outer).unwrap();
+    let validator =
+        XsdValidator::from_schema_with_base_path(&schema_doc, Some(&outer_path)).unwrap();
+    let doc = parse(r#"<o:item xmlns:o="urn:outer">not-an-int</o:item>"#).unwrap();
+    let errors: Vec<String> = validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect();
+
+    fs::remove_dir_all(&dir).ok();
+    assert!(
+        errors.iter().any(|e| e.contains("not a valid int")),
+        "imported int-based type should reject non-integer content, got {errors:?}"
+    );
+}
+
+#[test]
+fn unknown_named_xsd_type_fails_closed() {
+    // An unresolved schema type reference must be a validation error. Treating
+    // it as string-like content would silently bypass the intended constraint.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:i="urn:inner"
+           xmlns:o="urn:outer"
+           targetNamespace="urn:outer"
+           elementFormDefault="qualified">
+  <xs:element name="item" type="i:Missing"/>
+</xs:schema>"#;
+
+    let errors = validate(schema, r#"<o:item xmlns:o="urn:outer">anything</o:item>"#);
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("Type '{urn:inner}Missing' not found")),
+        "expected unresolved type error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_identity_constraints_use_namespace_uris() {
+    // Identity-constraint selectors and fields must compare expanded names.
+    // The valid document reuses a local name in another namespace; only the
+    // target namespace should participate in the key.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:r="urn:root"
+           xmlns:v="urn:vehicle"
+           targetNamespace="urn:root"
+           elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="##any" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="vehicle_ids">
+      <xs:selector xpath=".//v:vehicle"/>
+      <xs:field xpath="@v:id"/>
+    </xs:key>
+  </xs:element>
+</xs:schema>"###;
+
+    let valid = r#"<r:root xmlns:r="urn:root" xmlns:v="urn:vehicle" xmlns:o="urn:other">
+  <v:vehicle v:id="1"/>
+  <o:vehicle v:id="1"/>
+</r:root>"#;
+    assert!(validate(schema, valid).is_empty());
+
+    let invalid = r#"<r:root xmlns:r="urn:root" xmlns:v="urn:vehicle">
+  <v:vehicle v:id="1"/>
+  <v:vehicle v:id="1"/>
+</r:root>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("duplicate value")),
+        "expected duplicate key error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_attribute_wildcard_union_stays_namespace_precise() {
+    // Attribute wildcard extension combines namespace constraints. The union
+    // should allow only the local and target namespaces configured by the
+    // schema, not arbitrary foreign attributes.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:complexType name="Base">
+    <xs:anyAttribute namespace="##local" processContents="skip"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:extension base="t:Base">
+        <xs:anyAttribute namespace="##targetNamespace" processContents="skip"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="r" type="t:Derived"/>
+</xs:schema>"###;
+
+    let valid = r#"<t:r xmlns:t="urn:t" local="ok" t:target="ok"/>"#;
+    assert!(validate(schema, valid).is_empty());
+
+    let invalid = r#"<t:r xmlns:t="urn:t" xmlns:f="urn:f" local="ok" t:target="ok" f:bad="no"/>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("not allowed by wildcard")),
+        "expected wildcard namespace error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_complex_type_derivation_cycles_are_rejected() {
+    // Recursive complex-type derivation can otherwise loop while resolving the
+    // effective content model. The validator should detect the cycle and report
+    // it instead of recursing indefinitely.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:complexType name="A">
+    <xs:complexContent><xs:extension base="t:B"/></xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="B">
+    <xs:complexContent><xs:extension base="t:A"/></xs:complexContent>
+  </xs:complexType>
+  <xs:element name="r" type="t:A"/>
+</xs:schema>"#;
+
+    let errors = validate(schema, r#"<t:r xmlns:t="urn:t"/>"#);
+    assert!(
+        errors.iter().any(|e| e.contains("derivation cycle")),
+        "expected derivation cycle error, got {errors:?}"
+    );
+}

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -171,6 +171,33 @@ fn dom_mutation_rejects_invalid_and_cyclic_node_ids() {
 }
 
 #[test]
+fn xpath_node_sets_follow_mutated_document_order() {
+    // Arena allocation order is not necessarily document order after DOM
+    // mutation. XPath node-sets must follow the current tree links.
+    let mut doc = parse("<root><a/><b/><c/></root>").unwrap();
+    let root = doc.document_element().unwrap();
+    let children = doc.children(root);
+    let a = children[0];
+    let c = children[2];
+    doc.insert_before(root, c, a);
+
+    let eval = XPathEvaluator::new();
+    let nodes = eval.select_nodes(&doc, root, "*").unwrap();
+    let names: Vec<&str> = nodes
+        .iter()
+        .map(|&node| doc.element(node).unwrap().name.local_name.as_ref())
+        .collect();
+    assert_eq!(names, vec!["c", "a", "b"]);
+
+    let nodes = eval.select_nodes(&doc, root, "a | b | c").unwrap();
+    let names: Vec<&str> = nodes
+        .iter()
+        .map(|&node| doc.element(node).unwrap().name.local_name.as_ref())
+        .collect();
+    assert_eq!(names, vec!["c", "a", "b"]);
+}
+
+#[test]
 fn xpath_name_tests_are_namespace_aware() {
     // XPath prefixes are expression bindings, not document prefix text. This
     // verifies unprefixed tests match only no-namespace nodes and unbound

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -228,6 +228,27 @@ fn xpath_axis_expansion_is_budgeted() {
 }
 
 #[test]
+fn xpath_axis_budget_is_not_double_charged_after_name_test() {
+    // Axis traversal already charges returned nodes. A matching name test must
+    // not charge the same node again or a one-node child lookup with budget 1
+    // would fail.
+    let doc = parse("<r><a/></r>").unwrap();
+    let root = doc.document_element().unwrap();
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(1)
+        .select_nodes(&doc, root, "a")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(0)
+        .select_nodes(&doc, root, "a")
+        .expect_err("child axis must still charge returned nodes");
+    assert!(err.to_string().contains("maximum node visit budget of 0"));
+}
+
+#[test]
 fn xpath_id_function_scan_is_budgeted() {
     // id() performs a document-wide lookup. It must consume the same visit
     // budget as axis expansion so callers can bound adversarial lookups.

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -228,6 +228,32 @@ fn xpath_axis_expansion_is_budgeted() {
 }
 
 #[test]
+fn xpath_id_function_scan_is_budgeted() {
+    // id() performs a document-wide lookup. It must consume the same visit
+    // budget as axis expansion so callers can bound adversarial lookups.
+    let mut xml = String::from("<r>");
+    for i in 0..64 {
+        xml.push_str(&format!(r#"<item id="item-{i}"/>"#));
+    }
+    xml.push_str(r#"<item id="target"/></r>"#);
+
+    let doc = parse(&xml).unwrap();
+    let root = doc.root();
+
+    let err = XPathEvaluator::new()
+        .with_max_node_visits(0)
+        .select_nodes(&doc, root, "id('target')")
+        .expect_err("low node visit budget must stop id() expansion");
+    assert!(err.to_string().contains("maximum node visit budget of 0"));
+
+    let nodes = XPathEvaluator::new()
+        .with_max_node_visits(100)
+        .select_nodes(&doc, root, "id('target')")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+}
+
+#[test]
 fn serializers_replace_invalid_xml_characters() {
     let mut writer = XmlWriter::new();
     writer.start_element("r", &[("a", "x\u{0001}y")]);
@@ -279,6 +305,53 @@ fn xsd_rejects_malformed_time_and_datetime_values() {
     assert!(!validate(schema, "<t>12:00:0é0+000</t>").is_empty());
     assert!(!validate(schema, "<dt>2024-01-01T12:00:00+99:00</dt>").is_empty());
     assert!(!validate(schema, "<dt>2024-01-01T12:00:0é0+000</dt>").is_empty());
+}
+
+#[test]
+fn xsd_date_like_types_reject_out_of_range_timezone_offsets() {
+    // Date-like XSD types use the same timezone range as xs:time/dateTime:
+    // offsets are limited to +/-14:00 and minutes must be 00-59.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="date" type="xs:date"/>
+  <xs:element name="gy" type="xs:gYear"/>
+  <xs:element name="gym" type="xs:gYearMonth"/>
+  <xs:element name="gm" type="xs:gMonth"/>
+  <xs:element name="gmd" type="xs:gMonthDay"/>
+  <xs:element name="gd" type="xs:gDay"/>
+</xs:schema>"#;
+
+    for invalid in [
+        "<date>2024-01-01+99:99</date>",
+        "<gy>2024+99:99</gy>",
+        "<gym>2024-01+99:99</gym>",
+        "<gm>--01+99:99</gm>",
+        "<gmd>--01-01+99:99</gmd>",
+        "<gd>---01+99:99</gd>",
+        "<date>2024-01-01+14:01</date>",
+        "<gy>2024+14:01</gy>",
+        "<gym>2024-01+14:01</gym>",
+        "<gm>--01+14:01</gm>",
+        "<gmd>--01-01+14:01</gmd>",
+        "<gd>---01+14:01</gd>",
+    ] {
+        let errors = validate(schema, invalid);
+        assert!(!errors.is_empty(), "expected {invalid} to be invalid");
+    }
+
+    for valid in [
+        "<date>2024-01-01+14:00</date>",
+        "<gy>2024+14:00</gy>",
+        "<gym>2024-01+14:00</gym>",
+        "<gm>--01+14:00</gm>",
+        "<gmd>--01-01+14:00</gmd>",
+        "<gd>---01+14:00</gd>",
+    ] {
+        let errors = validate(schema, valid);
+        assert!(
+            errors.is_empty(),
+            "expected {valid} to be valid, got {errors:?}"
+        );
+    }
 }
 
 #[test]
@@ -398,6 +471,122 @@ fn xsd_identity_constraints_use_namespace_uris() {
     assert!(
         errors.iter().any(|e| e.contains("duplicate value")),
         "expected duplicate key error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_identity_constraint_selector_uses_local_namespace_scope() {
+    // Namespace declarations on xs:selector are in scope for that XPath. If
+    // ignored, the selector matches nothing and duplicate key values bypass.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:v"
+           elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="vehicle" type="xs:string" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="vehicle_texts">
+      <xs:selector xmlns:v="urn:v" xpath="v:vehicle"/>
+      <xs:field xpath="."/>
+    </xs:key>
+  </xs:element>
+</xs:schema>"#;
+
+    let invalid = r#"<v:root xmlns:v="urn:v">
+  <v:vehicle>same</v:vehicle>
+  <v:vehicle>same</v:vehicle>
+</v:root>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("duplicate value")),
+        "expected selector-local namespace to expose duplicate key, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_identity_constraint_field_uses_local_namespace_scope() {
+    // Namespace declarations on xs:field are in scope for that XPath. xs:unique
+    // skips absent fields, so ignoring the local binding would accept duplicates.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:v"
+           elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="vehicle" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique xmlns:s="urn:v" name="vehicle_ids">
+      <xs:selector xpath="s:vehicle"/>
+      <xs:field xmlns:f="urn:v" xpath="f:id"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>"#;
+
+    let invalid = r#"<v:root xmlns:v="urn:v">
+  <v:vehicle><v:id>same</v:id></v:vehicle>
+  <v:vehicle><v:id>same</v:id></v:vehicle>
+</v:root>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("duplicate value")),
+        "expected field-local namespace to expose duplicate unique value, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_keyref_field_uses_local_namespace_scope() {
+    // Keyref fields with locally declared prefixes must resolve before the
+    // tuple lookup. Otherwise missing field values are skipped and bad refs pass.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:v"
+           elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="vehicle" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="id" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key xmlns:s="urn:v" name="vehicle_ids">
+      <xs:selector xpath="s:vehicle"/>
+      <xs:field xpath="s:id"/>
+    </xs:key>
+    <xs:keyref xmlns:s="urn:v" name="vehicle_refs" refer="vehicle_ids">
+      <xs:selector xpath="s:ref"/>
+      <xs:field xmlns:f="urn:v" xpath="f:id"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>"#;
+
+    let invalid = r#"<v:root xmlns:v="urn:v">
+  <v:vehicle><v:id>known</v:id></v:vehicle>
+  <v:ref><v:id>missing</v:id></v:ref>
+</v:root>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        errors.iter().any(|e| e.contains("no matching key value")),
+        "expected field-local namespace to expose bad keyref, got {errors:?}"
     );
 }
 

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -1,6 +1,15 @@
-//! Comprehensive tests for XML serialization, round-trip fidelity, and the XmlWriter builder.
+//! Comprehensive tests for XML serialization, round-trip fidelity, and the
+//! `XmlWriter` builder.
+//!
+//! The suite is grouped by serialization surface. Simple round-trip cases pin
+//! byte-for-byte behavior for parsed XML, while later sections cover security
+//! defaults, subtree serialization, writer escaping, and streaming output.
 
 // ─── Round-trip: to_xml() ───────────────────────────────────────────────────
+
+// These tests cover parsed XML that should serialize back to the same compact
+// representation. They intentionally use small fixtures so each XML construct
+// is isolated when a round-trip regression occurs.
 
 #[test]
 fn roundtrip_simple() {
@@ -136,34 +145,44 @@ fn roundtrip_attr_with_lt() {
     assert_eq!(doc.to_xml(), xml);
 }
 
-// ─── DOCTYPE preservation ───────────────────────────────────────────────────
+// ─── DOCTYPE handling ───────────────────────────────────────────────────────
+
+// DOCTYPE declarations are stored on the Document but omitted by default when
+// serializing. These tests pin both the secure default and the explicit trusted
+// opt-in path.
 
 #[test]
-fn doctype_preserved_system() {
+fn doctype_omitted_by_default_system() {
     let xml = r#"<?xml version="1.0"?><!DOCTYPE root SYSTEM "root.dtd"><root/>"#;
     let doc = uppsala::parse(xml).unwrap();
     assert_eq!(
         doc.doctype.as_deref(),
         Some(r#"<!DOCTYPE root SYSTEM "root.dtd">"#)
     );
-    assert_eq!(doc.to_xml(), xml);
+    assert_eq!(doc.to_xml(), r#"<?xml version="1.0"?><root/>"#);
+    let opts = uppsala::XmlWriteOptions::compact().with_doctype(true);
+    assert_eq!(doc.to_xml_with_options(&opts), xml);
 }
 
 #[test]
-fn doctype_preserved_public() {
+fn doctype_omitted_by_default_public() {
     let xml = r#"<?xml version="1.0"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html/>"#;
     let doc = uppsala::parse(xml).unwrap();
     assert!(doc.doctype.is_some());
-    assert_eq!(doc.to_xml(), xml);
+    assert_eq!(doc.to_xml(), r#"<?xml version="1.0"?><html/>"#);
+    let opts = uppsala::XmlWriteOptions::compact().with_doctype(true);
+    assert_eq!(doc.to_xml_with_options(&opts), xml);
 }
 
 #[test]
-fn doctype_preserved_internal_subset() {
+fn doctype_omitted_by_default_internal_subset() {
     let xml =
         "<?xml version=\"1.0\"?><!DOCTYPE root [\n<!ELEMENT root (#PCDATA)>\n]><root>hello</root>";
     let doc = uppsala::parse(xml).unwrap();
     assert!(doc.doctype.is_some());
-    assert_eq!(doc.to_xml(), xml);
+    assert_eq!(doc.to_xml(), "<?xml version=\"1.0\"?><root>hello</root>");
+    let opts = uppsala::XmlWriteOptions::compact().with_doctype(true);
+    assert_eq!(doc.to_xml_with_options(&opts), xml);
 }
 
 #[test]
@@ -174,6 +193,9 @@ fn no_doctype_is_none() {
 }
 
 // ─── Escaping edge cases ────────────────────────────────────────────────────
+
+// Escaping tests verify that the serializer emits XML syntax characters as
+// entity references in text and attribute-value positions.
 
 #[test]
 fn text_escaping_amp_lt_gt() {
@@ -191,6 +213,9 @@ fn attr_escaping_quote() {
 
 // ─── Display trait ──────────────────────────────────────────────────────────
 
+// Display is intended as a convenience wrapper over the compact XML
+// serializer, so it should stay byte-equivalent with `to_xml()`.
+
 #[test]
 fn display_matches_to_xml() {
     let xml =
@@ -206,6 +231,9 @@ fn display_simple() {
 }
 
 // ─── node_to_xml (subtree serialization) ────────────────────────────────────
+
+// Subtree serialization excludes document-level metadata and writes only the
+// selected node and descendants. Text nodes still need normal escaping.
 
 #[test]
 fn node_to_xml_document_element() {
@@ -242,6 +270,9 @@ fn node_to_xml_text_node() {
 
 // ─── write_to (io::Write streaming) ────────────────────────────────────────
 
+// The streaming API should produce the same bytes as `to_xml()` without
+// requiring callers to allocate the final String themselves.
+
 #[test]
 fn write_to_vec() {
     let xml = "<root><child>text</child></root>";
@@ -262,6 +293,9 @@ fn write_to_matches_to_xml() {
 }
 
 // ─── XmlWriteOptions: expand_empty_elements ─────────────────────────────────
+
+// `expand_empty_elements` is required for canonical-style output. These tests
+// verify it affects both nested empty elements and an empty document element.
 
 #[test]
 fn expand_empty_elements() {
@@ -290,6 +324,9 @@ fn self_closing_default() {
 }
 
 // ─── XmlWriteOptions: pretty-printing ───────────────────────────────────────
+
+// Pretty-printing should indent element-only content while preserving mixed
+// content exactly, because injected whitespace would change text semantics.
 
 #[test]
 fn pretty_print_simple() {
@@ -350,6 +387,9 @@ fn pretty_print_expand_empty() {
 
 // ─── node_to_xml_with_options ───────────────────────────────────────────────
 
+// Options passed to subtree serialization should apply to the selected node in
+// the same way they apply to full-document serialization.
+
 #[test]
 fn node_to_xml_with_expand_empty() {
     let xml = "<root><a/></root>";
@@ -361,6 +401,9 @@ fn node_to_xml_with_expand_empty() {
 }
 
 // ─── Namespace declarations in serialization ────────────────────────────────
+
+// Namespace declarations are part of the element start tag and must survive
+// parse/serialize cycles so prefixed and default namespaces remain meaningful.
 
 #[test]
 fn namespace_declarations_preserved() {
@@ -381,6 +424,9 @@ fn prefixed_namespace_preserved() {
 }
 
 // ─── XmlWriter builder tests ────────────────────────────────────────────────
+
+// XmlWriter is the programmatic construction API. These tests cover the same
+// XML constructs as DOM serialization, but through direct builder calls.
 
 #[test]
 fn writer_basic() {
@@ -532,7 +578,7 @@ fn writer_namespace_attrs() {
 
 #[test]
 fn writer_rsa_key_value_pattern() {
-    // This mimics the pattern from bergshamra's key.rs
+    // XML signature key material exercises nested prefixed element names.
     let mut w = uppsala::XmlWriter::new();
     let prefix = "ds";
     w.start_element(&format!("{prefix}:RSAKeyValue"), &[]);
@@ -551,7 +597,8 @@ fn writer_rsa_key_value_pattern() {
 
 #[test]
 fn writer_ec_key_value_pattern() {
-    // Mimics bergshamra's ECKeyValue pattern
+    // ECKeyValue output combines a default namespace, an empty element with an
+    // attribute, and base64-like text content.
     let mut w = uppsala::XmlWriter::new();
     w.start_element(
         "ECKeyValue",
@@ -608,6 +655,8 @@ fn writer_into_bytes() {
 }
 
 // ─── write_to_with_options ──────────────────────────────────────────────────
+
+// This pins the combination of streaming output and non-default write options.
 
 #[test]
 fn write_to_with_pretty_options() {

--- a/tests/xml_conformance.rs
+++ b/tests/xml_conformance.rs
@@ -5,7 +5,6 @@
 //! XML declarations, and edge cases from the W3C XML 1.0 specification.
 
 use uppsala::dom::{NodeKind, QName};
-use uppsala::error::XmlError;
 
 // ─── Well-formed documents ───────────────────────────────
 

--- a/tests/xpath_conformance.rs
+++ b/tests/xpath_conformance.rs
@@ -259,6 +259,39 @@ fn preceding_sibling_axis() {
     assert_eq!(nodes.len(), 2);
 }
 
+#[test]
+fn reverse_axis_predicates_use_axis_order() {
+    let xml = "<root><a/><b><c><d/></c></b><e/></root>";
+    let doc = uppsala::parse(xml).unwrap();
+    let root = doc.document_element().unwrap();
+    let children = doc.children(root);
+    let e = children[2];
+    let b = children[1];
+    let c = doc.children(b)[0];
+    let d = doc.children(c)[0];
+    let eval = uppsala::XPathEvaluator::new();
+
+    let nodes = eval
+        .select_nodes(&doc, e, "preceding-sibling::*[1]")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(doc.element(nodes[0]).unwrap().name.local_name, "b");
+
+    let nodes = eval
+        .select_nodes(&doc, e, "preceding-sibling::*[last()]")
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(doc.element(nodes[0]).unwrap().name.local_name, "a");
+
+    let nodes = eval.select_nodes(&doc, d, "ancestor::*[1]").unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(doc.element(nodes[0]).unwrap().name.local_name, "c");
+
+    let nodes = eval.select_nodes(&doc, d, "ancestor::*[last()]").unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(doc.element(nodes[0]).unwrap().name.local_name, "root");
+}
+
 // ─── Predicates ─────────────────────────────────────────
 
 #[test]

--- a/tests/xpath_conformance.rs
+++ b/tests/xpath_conformance.rs
@@ -3,7 +3,7 @@
 //! Tests cover axes, node tests, predicates, functions, operators,
 //! and the attribute axis implementation.
 
-use uppsala::dom::{NodeId, NodeKind, QName};
+use uppsala::dom::NodeId;
 use uppsala::xpath::XPathValue;
 
 fn parse_and_eval(xml: &str, xpath: &str) -> XPathValue {


### PR DESCRIPTION
Make secure behavior the default across the XML processing surface and add regression coverage. This consolidates the 0.5.0 security-hardening pass and the follow-up differential review (core findings) into a single change.

Parser / input:
- Cap entity replacement-text expansion nesting (DEFAULT_MAX_ENTITY_DEPTH=256) so a deep linear entity chain (e0 -> e1 -> ... -> eN) fails closed instead of overflowing the stack; the byte budget alone did not catch this.
- Reject odd-length UTF-16 byte streams instead of silently dropping the trailing half code unit.

Serialization (DOM + XmlWriter):
- Omit DOCTYPE by default to avoid handing an XXE-capable DOCTYPE downstream; opt back in with XmlWriteOptions::with_doctype(true).
- Validate programmatic element/attribute names as XML names, replacing invalid structural QNames with '_'.
- Sanitize processing-instruction targets as NCName (invalid -> '_') and rename the reserved 'xml' target; prevents '?>' target injection.
- Replace invalid XML characters on output so serialized text re-parses.
- Disambiguate colliding sanitized namespace prefixes (preserving both URIs) and skip impossible duplicate default-namespace declarations.

XPath 1.0:
- Make name tests namespace-aware and require explicit prefix bindings (no local-name-only fallback).
- Bound axis/predicate traversal with a configurable node-visit budget and charge node-set comparison (O(n*m)) against it, so a comparison built from cheap operands cannot run unbounded under the cap.
- Use saturating arithmetic and clamping in substring() so an inf/huge length argument cannot overflow (no panic in debug or release).

XSD validation:
- Fail closed on namespace mismatch, unresolved type references, malformed temporal values, and complex-type derivation cycles.
- Reject non-ASCII input up front in the gMonth/gDay/gMonthDay validators instead of slicing fixed byte ranges (no multibyte slice panic).
- Constrain xs:include/redefine/import file resolution to the schema base directory so an absolute or escaping schemaLocation cannot read arbitrary local files.
- Keep identity constraints and attribute-wildcard merging namespace-precise.

XSD regex engine:
- Enforce a per-match step budget and allocate the repetition 'seen' bitmap lazily so 'a*b*' over a long run stays linear and is correctly charged.
- Reject unknown Unicode property/block names at compile time (fail closed) so \P{IsTypo} cannot widen a pattern to match every character.

DOM:
- Make public mutation APIs no-op on invalid handles or cycle-forming moves.

Tests and docs:
- Add tests/security_audit.rs, tests/hardening_regressions.rs, and tests/security_regressions.rs pinning each finding, each with a "legitimate input still works" assertion.
- Add audit/ (proof-of-concept inputs and fuzz targets) and SECURITY_AUDIT.md.
- Add ADR 0007 documenting the hardening defaults and the differential-review second pass.

All W3C conformance suites remain at their prior pass rates (XML 100%, XSTS NIST/MS/Sun 100%); the library still builds with zero warnings.