### PR TITLE
fix(xsd): inherit is_list

### DIFF
--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -20,7 +20,7 @@ use crate::error::{XmlError, XmlResult};
 
 use super::composition::{process_schema_composition, CompositionState};
 use super::facet_resolution::{
-    resolve_content_model_list_item_facets, resolve_inline_list_item_facets,
+    resolve_content_model_list_item_facets, resolve_inline_list_item_facets, ListBasesMap,
 };
 use super::parser::{
     parse_attribute_group_def, parse_complex_type, parse_element_decl, parse_model_group_def,
@@ -453,11 +453,27 @@ impl XsdValidator {
                 })
                 .collect();
 
+        // Named simple types that are list types, so an inline type restricting
+        // one can inherit `is_list`/`item_type`/`item_facets` (issue #12). Built
+        // after the named-type list-resolution passes above, so the entries
+        // already carry resolved item types.
+        let list_bases: ListBasesMap = validator
+            .types
+            .iter()
+            .filter_map(|(k, td)| match td {
+                TypeDef::Simple(st) if st.is_list => {
+                    Some((k.clone(), (st.item_type.clone(), st.item_facets.clone())))
+                }
+                _ => None,
+            })
+            .collect();
+
         // Resolve inline list types in global element declarations
         for elem_decl in validator.elements.values_mut() {
             resolve_inline_list_item_facets(
                 &mut elem_decl.type_ref,
                 &resolved_items,
+                &list_bases,
                 &validator.target_namespace,
             );
         }
@@ -469,6 +485,7 @@ impl XsdValidator {
                 resolve_content_model_list_item_facets(
                     &mut ct.content,
                     &resolved_items,
+                    &list_bases,
                     &validator.target_namespace,
                 );
             }

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -12,7 +12,7 @@
 //!   4. List-type resolution passes (base-type propagation, item-type facets,
 //!      inline list-type facets in elements and content-model particles)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::dom::{Document, NodeKind};
@@ -434,6 +434,58 @@ impl XsdValidator {
                         st.item_facets = item_facets;
                     }
                 }
+            }
+        }
+
+        // Resolution pass 2b: derived list types (a `<restriction base="SomeList">`)
+        // inherit the item type and item-level facets of the list they restrict.
+        // Pass 1 propagates `is_list`/`item_type` but runs before pass 2 resolves
+        // the base's item facets, so item-level constraints (e.g. a pattern on a
+        // user-defined item type) would otherwise be silently dropped on a derived
+        // list type — accepting items the base would reject. Walk each restriction
+        // chain to the underlying `<list>` declaration (whose item meta pass 2 has
+        // fully resolved) and copy it down.
+        let derived_meta = type_keys2
+            .iter()
+            .filter_map(|key| {
+                // Only derived list types: a list reached via restriction, not
+                // a direct `<list>` declaration (which pass 2 already handles).
+                let is_derived_list = matches!(
+                    validator.types.get(key),
+                    Some(TypeDef::Simple(st))
+                        if st.is_list
+                            && st._base_type_local.is_some()
+                            && st._item_type_local.is_none()
+                );
+                if !is_derived_list {
+                    return None;
+                }
+                // Follow the base chain to the root list; its resolved item
+                // meta is the deepest list reached.
+                let mut cur = key.clone();
+                let mut seen = HashSet::new();
+                let mut meta = None;
+                while seen.insert(cur.clone()) {
+                    match validator.types.get(&cur) {
+                        Some(TypeDef::Simple(st)) if st.is_list => {
+                            meta = Some((st.item_type.clone(), st.item_facets.clone()));
+                            match &st._base_type_local {
+                                Some(base_local) => cur = (cur.0.clone(), base_local.clone()),
+                                None => break,
+                            }
+                        }
+                        _ => break,
+                    }
+                }
+                meta.map(|(it, ifac)| (key.clone(), it, ifac))
+            })
+            .collect::<Vec<_>>();
+        for (key, item_type, item_facets) in derived_meta {
+            if let Some(TypeDef::Simple(st)) = validator.types.get_mut(&key) {
+                if item_type.is_some() {
+                    st.item_type = item_type;
+                }
+                st.item_facets = item_facets;
             }
         }
 

--- a/src/xsd/facet_resolution.rs
+++ b/src/xsd/facet_resolution.rs
@@ -12,16 +12,43 @@ use super::types::{BuiltInType, ContentModel, Facet, Particle, ParticleKind, Typ
 /// Type alias for resolved item facets map: (namespace, local_name) -> (base_type, facets).
 type ResolvedItemsMap = HashMap<(Option<String>, String), (BuiltInType, Vec<Facet>)>;
 
+/// Type alias for named list-type info: (namespace, local_name) -> (item_type, item_facets).
+/// Only contains entries for named simple types that are themselves list types,
+/// so presence in the map means "the base is a list".
+pub(super) type ListBasesMap = HashMap<(Option<String>, String), (Option<BuiltInType>, Vec<Facet>)>;
+
 /// Resolve list item facets for an inline SimpleTypeDef within a TypeRef.
 /// Also recurses into inline ComplexTypeDefs to resolve their content model particles.
 pub(super) fn resolve_inline_list_item_facets(
     type_ref: &mut TypeRef,
     resolved_items: &ResolvedItemsMap,
+    list_bases: &ListBasesMap,
     schema_ns: &Option<String>,
 ) {
     if let TypeRef::Inline(td) = type_ref {
         match td.as_mut() {
             TypeDef::Simple(st) => {
+                // An inline `<restriction base="SomeNamedListType">` does not
+                // carry `is_list` at parse time — only the base's local name.
+                // If that base is a list type, inherit list-ness (and the item
+                // type/facets) so length facets count items, not characters
+                // (issue #12). The global named-type pass in `builder.rs`
+                // handles this for named derived types; this covers anonymous
+                // inline types embedded in element declarations and particles.
+                if !st.is_list {
+                    if let Some(base_local) = &st._base_type_local {
+                        let base_key = (schema_ns.clone(), base_local.clone());
+                        if let Some((item_type, item_facets)) = list_bases.get(&base_key) {
+                            st.is_list = true;
+                            if st.item_type.is_none() {
+                                st.item_type = item_type.clone();
+                            }
+                            if st.item_facets.is_empty() {
+                                st.item_facets = item_facets.clone();
+                            }
+                        }
+                    }
+                }
                 if st.is_list {
                     if let Some(item_name) = &st._item_type_local {
                         let item_key = (schema_ns.clone(), item_name.clone());
@@ -33,7 +60,12 @@ pub(super) fn resolve_inline_list_item_facets(
                 }
             }
             TypeDef::Complex(ct) => {
-                resolve_content_model_list_item_facets(&mut ct.content, resolved_items, schema_ns);
+                resolve_content_model_list_item_facets(
+                    &mut ct.content,
+                    resolved_items,
+                    list_bases,
+                    schema_ns,
+                );
             }
         }
     }
@@ -43,14 +75,15 @@ pub(super) fn resolve_inline_list_item_facets(
 pub(super) fn resolve_content_model_list_item_facets(
     content: &mut ContentModel,
     resolved_items: &ResolvedItemsMap,
+    list_bases: &ListBasesMap,
     schema_ns: &Option<String>,
 ) {
     match content {
         ContentModel::Sequence(particles, _, _) | ContentModel::Choice(particles, _, _) => {
-            resolve_particles_list_item_facets(particles, resolved_items, schema_ns);
+            resolve_particles_list_item_facets(particles, resolved_items, list_bases, schema_ns);
         }
         ContentModel::All(particles) => {
-            resolve_particles_list_item_facets(particles, resolved_items, schema_ns);
+            resolve_particles_list_item_facets(particles, resolved_items, list_bases, schema_ns);
         }
         _ => {}
     }
@@ -60,15 +93,21 @@ pub(super) fn resolve_content_model_list_item_facets(
 fn resolve_particles_list_item_facets(
     particles: &mut [Particle],
     resolved_items: &ResolvedItemsMap,
+    list_bases: &ListBasesMap,
     schema_ns: &Option<String>,
 ) {
     for particle in particles.iter_mut() {
         match &mut particle.kind {
             ParticleKind::Element(decl) => {
-                resolve_inline_list_item_facets(&mut decl.type_ref, resolved_items, schema_ns);
+                resolve_inline_list_item_facets(
+                    &mut decl.type_ref,
+                    resolved_items,
+                    list_bases,
+                    schema_ns,
+                );
             }
             ParticleKind::Sequence(sub) | ParticleKind::Choice(sub) => {
-                resolve_particles_list_item_facets(sub, resolved_items, schema_ns);
+                resolve_particles_list_item_facets(sub, resolved_items, list_bases, schema_ns);
             }
             ParticleKind::Any { .. } => {}
         }

--- a/tests/xsd_conformance.rs
+++ b/tests/xsd_conformance.rs
@@ -546,3 +546,72 @@ fn xsd_list_inheritance() {
     // Item type is still enforced: a non-double item must fail.
     assert!(validate_xml_against_xsd("<ThreePoint>1.2 abc 4.5</ThreePoint>", xsd).is_err());
 }
+
+#[test]
+fn xsd_derived_list_inherits_item_facets() {
+    // A named list type derived via <restriction> over another list type must
+    // inherit the base list's item-level facets (e.g. a pattern on a
+    // user-defined item type). Otherwise item constraints are silently dropped
+    // and invalid items are accepted (fail-open). Regression for the
+    // differential-review finding on `list_bases` / builder list passes.
+    let xsd = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="HexByte">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9A-Fa-f]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="HexList">
+    <xs:list itemType="HexByte"/>
+  </xs:simpleType>
+  <xs:simpleType name="ShortHexList">
+    <xs:restriction base="HexList">
+      <xs:maxLength value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="data" type="ShortHexList"/>
+</xs:schema>"#;
+
+    // Valid: two well-formed hex bytes, within maxLength.
+    assert!(validate_xml_against_xsd("<data>AA BB</data>", xsd).is_ok());
+    // Item pattern must still be enforced through the derived list type.
+    assert!(validate_xml_against_xsd("<data>AA ZZ</data>", xsd).is_err());
+    // List-level maxLength (item count) must still be enforced.
+    assert!(validate_xml_against_xsd("<data>AA BB CC DD</data>", xsd).is_err());
+}
+
+#[test]
+fn xsd_inline_restriction_over_derived_list_enforces_item_facets() {
+    // Combines both fixes: an *inline* simpleType restricting a *derived* list
+    // type must inherit both is_list and the ultimate base list's item facets.
+    let xsd = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="HexByte">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9A-Fa-f]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="HexList">
+    <xs:list itemType="HexByte"/>
+  </xs:simpleType>
+  <xs:simpleType name="ShortHexList">
+    <xs:restriction base="HexList">
+      <xs:maxLength value="4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="data">
+    <xs:simpleType>
+      <xs:restriction base="ShortHexList">
+        <xs:length value="2"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+
+    // Exactly two well-formed hex bytes.
+    assert!(validate_xml_against_xsd("<data>AA BB</data>", xsd).is_ok());
+    // length=2 counts items, not characters.
+    assert!(validate_xml_against_xsd("<data>AA BB CC</data>", xsd).is_err());
+    // Item pattern enforced transitively through the inline restriction.
+    assert!(validate_xml_against_xsd("<data>AA ZZ</data>", xsd).is_err());
+}

--- a/tests/xsd_conformance.rs
+++ b/tests/xsd_conformance.rs
@@ -513,3 +513,36 @@ fn xsd_nested_complex_types() {
     let xml = "<order><customer><name>Bob</name></customer><total>99.95</total></order>";
     assert!(validate_xml_against_xsd(xml, xsd).is_ok());
 }
+
+// ─── List-type inheritance (issue #12) ─────────────────────────────
+
+#[test]
+fn xsd_list_inheritance() {
+    // An inline <xs:simpleType> restricting a named list type must inherit
+    // `is_list` from the base, so a `length` facet counts list *items*, not
+    // characters. Regression test for issue #12.
+    let xsd = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="DoubleListSimpleType">
+    <xs:list itemType="xs:double"/>
+  </xs:simpleType>
+  <xs:element name="ThreePoint" nillable="false">
+    <xs:simpleType>
+      <xs:restriction base="DoubleListSimpleType">
+        <xs:length value="3" fixed="true"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+
+    // Exactly three list items — valid regardless of each item's char length.
+    assert!(validate_xml_against_xsd("<ThreePoint>1.2 3.4 4.5</ThreePoint>", xsd).is_ok());
+    assert!(validate_xml_against_xsd("<ThreePoint>1 2 3</ThreePoint>", xsd).is_ok());
+
+    // Wrong number of items — must fail the length facet.
+    assert!(validate_xml_against_xsd("<ThreePoint>1.2 3.4</ThreePoint>", xsd).is_err());
+    assert!(validate_xml_against_xsd("<ThreePoint>1.2 3.4 3 4</ThreePoint>", xsd).is_err());
+
+    // Item type is still enforced: a non-double item must fail.
+    assert!(validate_xml_against_xsd("<ThreePoint>1.2 abc 4.5</ThreePoint>", xsd).is_err());
+}


### PR DESCRIPTION
Fixes #12, an inline <xs:simpleType> whose <xs:restriction base="..."> points at a named list type never inherited is_list, so an xs:length facet counted characters instead of list items. A 3-item list constrained to length 3 was rejected because the validator saw the character count, not the item count.

The parser leaves is_list=false for a restriction over a user-defined base (it only records the base local name), and the existing list- inheritance pass in builder.rs only propagated is_list between named types in validator.types -- it never reached the anonymous inline type embedded in an element declaration.

- builder.rs: build a list_bases map (named simple types that are list types, with their resolved item type/facets) and thread it into the inline list-resolution pass.
- facet_resolution.rs: resolve_inline_list_item_facets now inherits is_list/item_type/item_facets from a named base list type before resolving item facets, covering anonymous inline types in element declarations and complex-type particles.
- tests: add xsd_list_inheritance regression test.