### PR TITLE
fix(dom): namespace-aware serialization of programmatic QNames

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1555,7 +1555,11 @@ impl<'a> NsScope<'a> {
     /// (the innermost binding for each prefix wins). The reserved `xml` and
     /// `xmlns` prefixes are never returned: reusing them for an arbitrary URI
     /// would defeat the "reserved prefixes are never rebound" guarantee and
-    /// produce output that re-parses into the wrong namespace.
+    /// produce output that re-parses into the wrong namespace. Prefixes that are
+    /// not valid XML NCNames are also skipped: reusing an invalid programmatic
+    /// prefix would yield a QName like `bad prefix:Foo` that `safe_xml_qname`
+    /// collapses to `_` (dropping the local name); the caller allocates a fresh
+    /// `nsN` prefix instead.
     fn prefix_for(&self, uri: &str) -> Option<String> {
         // Track seen prefixes by reference (no cloning); the innermost binding
         // for each prefix is its effective one, so a prefix seen earlier shadows
@@ -1568,6 +1572,7 @@ impl<'a> NsScope<'a> {
                     && !p.is_empty()
                     && p.as_ref() != "xml"
                     && p.as_ref() != "xmlns"
+                    && crate::writer::is_valid_xml_ncname(p.as_ref())
                     && u.as_ref() == uri
                 {
                     return Some(p.as_ref().to_string());

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -6,7 +6,7 @@
 //! mutation straightforward.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 /// A unique identifier for a node within a [`Document`].
@@ -1330,19 +1330,22 @@ impl<'a> Document<'a> {
                     write_indent(out, opts, depth)?;
                 }
                 out.write_char('<')?;
-                let raw_pname = elem.name.prefixed_name();
-                let pname = crate::writer::safe_xml_qname(&raw_pname);
-                out.write_str(&pname)?;
-                // Track names already emitted for this start tag so sanitized
-                // programmatic attributes cannot collide into duplicate XML.
-                let mut seen_attrs = Vec::new();
                 // Namespace-aware serialization: alongside the element's stored
                 // declarations, synthesize any declarations needed so its own
                 // QName and its attributes' QNames resolve under the current
                 // scope (issue #2). For parsed documents the stored declarations
                 // already satisfy every QName, so nothing extra is emitted.
-                let (synthesized, attr_overrides, child_local) =
+                let (synthesized, elem_name_override, attr_overrides, child_local) =
                     plan_element_namespaces(elem, scope);
+                let raw_pname = match &elem_name_override {
+                    Some(name) => Cow::Borrowed(name.as_str()),
+                    None => elem.name.prefixed_name(),
+                };
+                let pname = crate::writer::safe_xml_qname(&raw_pname);
+                out.write_str(&pname)?;
+                // Track names already emitted for this start tag so sanitized
+                // programmatic attributes cannot collide into duplicate XML.
+                let mut seen_attrs = Vec::new();
                 // Namespace declarations. Sanitized prefixes can collide (two
                 // distinct invalid prefixes both collapse to `_`), which would
                 // emit duplicate `xmlns:_` attributes and produce not-well-formed
@@ -1540,15 +1543,14 @@ impl<'a> NsScope<'a> {
     /// Find a non-empty prefix currently bound to `uri`, respecting shadowing
     /// (the innermost binding for each prefix wins).
     fn prefix_for(&self, uri: &str) -> Option<String> {
-        let mut seen: Vec<String> = Vec::new();
+        // Track seen prefixes by reference (no cloning); the innermost binding
+        // for each prefix is its effective one, so a prefix seen earlier shadows
+        // any later (outer) binding.
+        let mut seen: HashSet<&str> = HashSet::new();
         let mut cur = Some(self);
         while let Some(s) = cur {
             for (p, u) in s.local.iter().rev() {
-                if seen.iter().any(|x| x == p) {
-                    continue;
-                }
-                seen.push(p.clone());
-                if !p.is_empty() && u == uri {
+                if seen.insert(p.as_str()) && !p.is_empty() && u == uri {
                     return Some(p.clone());
                 }
             }
@@ -1558,13 +1560,98 @@ impl<'a> NsScope<'a> {
     }
 }
 
+/// Allocate a fresh `nsN` prefix that is not currently bound in `scope` plus the
+/// declarations collected so far for this element.
+fn alloc_ns_prefix(scope: &NsScope, child_local: &[NsDecl]) -> String {
+    let mut n = 0usize;
+    loop {
+        let cand = format!("ns{}", n);
+        let taken = {
+            let cur = NsScope {
+                parent: Some(scope),
+                local: child_local,
+            };
+            cur.resolve(&cand).is_some()
+        };
+        if !taken {
+            return cand;
+        }
+        n += 1;
+    }
+}
+
+/// Return an existing non-empty prefix bound to `uri`, or allocate a fresh one
+/// and record a declaration for it. Used when a prefix is required (namespaced
+/// attribute) or when the desired prefix is unusable.
+fn prefix_for_or_alloc(
+    scope: &NsScope,
+    child_local: &mut Vec<NsDecl>,
+    synthesized: &mut Vec<NsDecl>,
+    uri: &str,
+) -> String {
+    let reuse = {
+        let cur = NsScope {
+            parent: Some(scope),
+            local: child_local,
+        };
+        cur.prefix_for(uri)
+    };
+    if let Some(p) = reuse {
+        return p;
+    }
+    let p = alloc_ns_prefix(scope, child_local);
+    child_local.push((p.clone(), uri.to_string()));
+    synthesized.push((p.clone(), uri.to_string()));
+    p
+}
+
+/// Ensure `desired_prefix` (empty string = default namespace) resolves to `uri`
+/// for this element, recording any declaration that must be emitted. Returns
+/// `Some(prefix)` when the QName must be rewritten to use a *different* prefix —
+/// because `desired_prefix` is already declared on this same start tag bound to
+/// another URI and a start tag cannot carry two bindings for one prefix — or
+/// `None` when `desired_prefix` works as-is.
+fn ensure_binding(
+    scope: &NsScope,
+    child_local: &mut Vec<NsDecl>,
+    synthesized: &mut Vec<NsDecl>,
+    desired_prefix: &str,
+    uri: &str,
+) -> Option<String> {
+    let current = {
+        let cur = NsScope {
+            parent: Some(scope),
+            local: child_local,
+        };
+        cur.resolve(desired_prefix).map(|s| s.to_string())
+    };
+    if current.as_deref() == Some(uri) {
+        return None; // already correctly bound (here or via an ancestor)
+    }
+    if !child_local.iter().any(|(p, _)| p == desired_prefix) {
+        // Not declared on this element yet: declare it here, shadowing any
+        // ancestor binding. The QName keeps its own prefix.
+        child_local.push((desired_prefix.to_string(), uri.to_string()));
+        synthesized.push((desired_prefix.to_string(), uri.to_string()));
+        return None;
+    }
+    // Same-element conflict: `desired_prefix` is already bound here to a different
+    // URI and cannot be redeclared, so bind `uri` to a different prefix and
+    // rewrite the QName to use it (otherwise the QName would silently resolve to
+    // the colliding declaration).
+    Some(prefix_for_or_alloc(scope, child_local, synthesized, uri))
+}
+
 /// Compute the namespace declarations a serialized element must emit so its own
 /// QName and its attributes' QNames resolve correctly under the inherited
 /// `scope`. Returns:
 /// - `synthesized` — declarations to emit *in addition to* the element's stored
 ///   `namespace_declarations` (which are still emitted verbatim),
+/// - `elem_name_override` — a replacement element tag name, set only when the
+///   element's own prefix collides with a stored declaration,
 /// - `attr_overrides` — a per-attribute display-name override, set only for a
-///   namespaced attribute that needs a prefix it does not carry, and
+///   namespaced attribute that needs a prefix it does not carry (or whose prefix
+///   collides), and
 /// - `child_local` — every binding (stored + synthesized) this element
 ///   introduces, for building the child scope.
 ///
@@ -1573,7 +1660,12 @@ impl<'a> NsScope<'a> {
 fn plan_element_namespaces(
     elem: &Element,
     scope: &NsScope,
-) -> (Vec<NsDecl>, Vec<Option<String>>, Vec<NsDecl>) {
+) -> (
+    Vec<NsDecl>,
+    Option<String>,
+    Vec<Option<String>>,
+    Vec<NsDecl>,
+) {
     let mut child_local: Vec<NsDecl> = elem
         .namespace_declarations
         .iter()
@@ -1581,18 +1673,8 @@ fn plan_element_namespaces(
         .collect();
     let mut synthesized: Vec<NsDecl> = Vec::new();
 
-    // Resolve `prefix` against the inherited scope plus the bindings collected so
-    // far for this element.
-    let bound = |prefix: &str, local: &[NsDecl]| -> Option<String> {
-        let cur = NsScope {
-            parent: Some(scope),
-            local,
-        };
-        cur.resolve(prefix).map(|s| s.to_string())
-    };
-
     // Element QName.
-    match (
+    let elem_name_override = match (
         elem.name.prefix.as_deref(),
         elem.name.namespace_uri.as_deref(),
     ) {
@@ -1600,30 +1682,30 @@ fn plan_element_namespaces(
             // Unprefixed element in no namespace: if a non-empty default
             // namespace is in scope it would otherwise capture this element, so
             // undeclare it with `xmlns=""`.
-            if matches!(bound("", &child_local).as_deref(), Some(d) if !d.is_empty()) {
+            let default_ns = {
+                let cur = NsScope {
+                    parent: Some(scope),
+                    local: &child_local,
+                };
+                cur.resolve("").map(|s| s.to_string())
+            };
+            if matches!(default_ns.as_deref(), Some(d) if !d.is_empty()) {
                 synthesized.push((String::new(), String::new()));
                 child_local.push((String::new(), String::new()));
             }
+            None
         }
-        (Some(_), None) => { /* prefixed but no URI: leave the name as-is */ }
-        (Some("xml"), Some(_)) => { /* the xml prefix is implicitly bound */ }
-        (Some(p), Some(u)) => {
-            if bound(p, &child_local).as_deref() != Some(u) {
-                synthesized.push((p.to_string(), u.to_string()));
-                child_local.push((p.to_string(), u.to_string()));
-            }
-        }
-        (None, Some(u)) => {
-            if bound("", &child_local).as_deref() != Some(u) {
-                synthesized.push((String::new(), u.to_string()));
-                child_local.push((String::new(), u.to_string()));
-            }
-        }
-    }
+        (Some(_), None) => None, // prefixed but no URI: leave the name as-is
+        (Some("xml"), Some(_)) => None, // the xml prefix is implicitly bound
+        (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, p, u)
+            .map(|q| format!("{}:{}", q, elem.name.local_name)),
+        (None, Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, "", u)
+            .map(|q| format!("{}:{}", q, elem.name.local_name)),
+    };
 
     // Attributes. An empty prefix never works for an attribute (attributes are
     // not in the default namespace), so a namespaced-but-prefixless attribute is
-    // given a prefix.
+    // always given a prefix.
     let mut attr_overrides = Vec::with_capacity(elem.attributes.len());
     for attr in &elem.attributes {
         let override_name = match (
@@ -1631,51 +1713,17 @@ fn plan_element_namespaces(
             attr.name.namespace_uri.as_deref(),
         ) {
             (_, None) | (Some("xml"), Some(_)) => None,
-            (Some(p), Some(u)) => {
-                if bound(p, &child_local).as_deref() != Some(u) {
-                    synthesized.push((p.to_string(), u.to_string()));
-                    child_local.push((p.to_string(), u.to_string()));
-                }
-                None
-            }
+            (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, p, u)
+                .map(|q| format!("{}:{}", q, attr.name.local_name)),
             (None, Some(u)) => {
-                let existing = {
-                    let cur = NsScope {
-                        parent: Some(scope),
-                        local: &child_local,
-                    };
-                    cur.prefix_for(u)
-                };
-                let pfx = match existing {
-                    Some(p) => p,
-                    None => {
-                        let mut n = 0usize;
-                        let p = loop {
-                            let cand = format!("ns{}", n);
-                            let unbound = {
-                                let cur = NsScope {
-                                    parent: Some(scope),
-                                    local: &child_local,
-                                };
-                                cur.resolve(&cand).is_none()
-                            };
-                            if unbound {
-                                break cand;
-                            }
-                            n += 1;
-                        };
-                        synthesized.push((p.clone(), u.to_string()));
-                        child_local.push((p.clone(), u.to_string()));
-                        p
-                    }
-                };
+                let pfx = prefix_for_or_alloc(scope, &mut child_local, &mut synthesized, u);
                 Some(format!("{}:{}", pfx, attr.name.local_name))
             }
         };
         attr_overrides.push(override_name);
     }
 
-    (synthesized, attr_overrides, child_local)
+    (synthesized, elem_name_override, attr_overrides, child_local)
 }
 
 impl<'a> Default for Document<'a> {

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1674,8 +1674,10 @@ fn ensure_binding<'e>(
 ///   uses it as the child scope.
 ///
 /// For a parsed document the stored declarations already satisfy every QName, so
-/// nothing is synthesized and output is byte-identical to before. Stored
-/// declarations are borrowed (not cloned), so a no-op plan allocates nothing.
+/// nothing is synthesized and output is byte-identical to before. The per-element
+/// cost is building the small planning vectors (`child_local` borrows the stored
+/// declarations rather than cloning them; `attr_overrides`); synthesized bindings
+/// and renamed QNames allocate only when actually required.
 fn plan_element_namespaces<'e>(
     elem: &'e Element,
     scope: &NsScope,
@@ -1709,6 +1711,11 @@ fn plan_element_namespaces<'e>(
             }
             None
         }
+        // A reserved prefix with no namespace URI must still be stripped: `xml`
+        // and `xmlns` are implicitly bound, so `xml:Foo` would re-parse into the
+        // XML namespace and `xmlns:Foo` into the XMLNS namespace, silently
+        // changing the element's namespace. Serialize the bare local name.
+        (Some("xml"), None) | (Some("xmlns"), None) => Some(elem.name.local_name.to_string()),
         (Some(_), None) => None, // prefixed but no URI: leave the name as-is
         // The XML namespace is bound to `xml` and only `xml`, and is never
         // declared. Any other prefix (or none) for that URI is rewritten to
@@ -1744,6 +1751,11 @@ fn plan_element_namespaces<'e>(
             attr.name.prefix.as_deref(),
             attr.name.namespace_uri.as_deref(),
         ) {
+            // A reserved prefix with no namespace URI is stripped: `xml`/`xmlns`
+            // are implicitly bound, so `xml:foo` would re-parse into the XML
+            // namespace and `xmlns:foo` would be read as a namespace declaration,
+            // changing the attribute's effective namespace.
+            (Some("xml"), None) | (Some("xmlns"), None) => Some(attr.name.local_name.to_string()),
             (_, None) => None,
             (Some("xml"), Some(u)) if u == xml_ns => None,
             (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", attr.name.local_name)),

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1684,9 +1684,19 @@ fn plan_element_namespaces<'e>(
 ) -> (Option<String>, Vec<Option<String>>, Vec<NsDecl<'e>>) {
     let xml_ns = crate::namespace::XML_NAMESPACE;
     let xmlns_ns = crate::namespace::XMLNS_NAMESPACE;
+    // Borrow the stored declarations, but drop the reserved bindings the parser's
+    // `NamespaceResolver::declare` ignores (namespace.rs): the `xmlns` prefix can
+    // never be declared, the `xml` prefix may only bind the XML namespace, and no
+    // prefix may bind the XMLNS namespace. Emitting them (e.g. `xmlns:xmlns=...`)
+    // would produce namespace-not-well-formed output.
     let mut child_local: Vec<NsDecl<'e>> = elem
         .namespace_declarations
         .iter()
+        .filter(|(p, u)| {
+            p.as_ref() != "xmlns"
+                && !(p.as_ref() == "xml" && u.as_ref() != xml_ns)
+                && u.as_ref() != xmlns_ns
+        })
         .map(|(p, u)| (Cow::Borrowed(p.as_ref()), Cow::Borrowed(u.as_ref())))
         .collect();
 

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1207,15 +1207,33 @@ impl<'a> Document<'a> {
     /// Useful for extracting XML fragments without the XML declaration or DOCTYPE.
     pub fn node_to_xml(&self, id: NodeId) -> String {
         let mut output = String::new();
-        self.write_node_to(id, &mut output, &XmlWriteOptions::default(), 0, false)
-            .unwrap();
+        let binds = self.ancestor_ns_bindings(id);
+        let scope = NsScope {
+            parent: None,
+            local: &binds,
+        };
+        self.write_node_to(
+            id,
+            &mut output,
+            &XmlWriteOptions::default(),
+            0,
+            false,
+            &scope,
+        )
+        .unwrap();
         output
     }
 
     /// Serialize a single node (and its subtree) with formatting options.
     pub fn node_to_xml_with_options(&self, id: NodeId, opts: &XmlWriteOptions) -> String {
         let mut output = String::new();
-        self.write_node_to(id, &mut output, opts, 0, false).unwrap();
+        let binds = self.ancestor_ns_bindings(id);
+        let scope = NsScope {
+            parent: None,
+            local: &binds,
+        };
+        self.write_node_to(id, &mut output, opts, 0, false, &scope)
+            .unwrap();
         output
     }
 
@@ -1260,10 +1278,37 @@ impl<'a> Document<'a> {
                 out.write_str(dt)?;
             }
         }
+        let root_scope = NsScope {
+            parent: None,
+            local: &[],
+        };
         for child in self.children(self.root) {
-            self.write_node_to(child, out, opts, 0, opts.indent.is_some())?;
+            self.write_node_to(child, out, opts, 0, opts.indent.is_some(), &root_scope)?;
         }
         Ok(())
+    }
+
+    /// Collect the namespace bindings in scope at `id` from its ancestors (not
+    /// including `id` itself), outermost-first. Used to seed fragment
+    /// serialization so a namespace already declared on an enclosing element is
+    /// treated as in-scope and not redundantly re-declared.
+    fn ancestor_ns_bindings(&self, id: NodeId) -> Vec<NsDecl> {
+        let mut chain = Vec::new();
+        let mut cur = self.parent(id);
+        while let Some(p) = cur {
+            chain.push(p);
+            cur = self.parent(p);
+        }
+        chain.reverse();
+        let mut binds = Vec::new();
+        for nid in chain {
+            if let Some(NodeKind::Element(e)) = self.node_kind(nid) {
+                for (pfx, uri) in &e.namespace_declarations {
+                    binds.push((pfx.to_string(), uri.to_string()));
+                }
+            }
+        }
+        binds
     }
 
     /// Internal: write a single node and its subtree to a `fmt::Write` sink.
@@ -1277,6 +1322,7 @@ impl<'a> Document<'a> {
         opts: &XmlWriteOptions,
         depth: usize,
         indent_self: bool,
+        scope: &NsScope,
     ) -> fmt::Result {
         match self.node_kind(id) {
             Some(NodeKind::Element(elem)) => {
@@ -1290,12 +1336,24 @@ impl<'a> Document<'a> {
                 // Track names already emitted for this start tag so sanitized
                 // programmatic attributes cannot collide into duplicate XML.
                 let mut seen_attrs = Vec::new();
+                // Namespace-aware serialization: alongside the element's stored
+                // declarations, synthesize any declarations needed so its own
+                // QName and its attributes' QNames resolve under the current
+                // scope (issue #2). For parsed documents the stored declarations
+                // already satisfy every QName, so nothing extra is emitted.
+                let (synthesized, attr_overrides, child_local) =
+                    plan_element_namespaces(elem, scope);
                 // Namespace declarations. Sanitized prefixes can collide (two
                 // distinct invalid prefixes both collapse to `_`), which would
                 // emit duplicate `xmlns:_` attributes and produce not-well-formed
                 // output. Disambiguate the prefix against names already emitted
                 // for this start tag so the result always re-parses.
-                for (prefix, uri) in &elem.namespace_declarations {
+                let declarations = elem
+                    .namespace_declarations
+                    .iter()
+                    .map(|(p, u)| (p.as_ref(), u.as_ref()))
+                    .chain(synthesized.iter().map(|(p, u)| (p.as_str(), u.as_str())));
+                for (prefix, uri) in declarations {
                     if prefix.is_empty() {
                         // A default-namespace declaration has the fixed name
                         // `xmlns`, which cannot be disambiguated; skip a
@@ -1324,16 +1382,26 @@ impl<'a> Document<'a> {
                     write_escaped_attr(out, uri)?;
                     out.write_char('"')?;
                 }
-                // Attributes
-                for attr in &elem.attributes {
+                // Attributes. A namespaced attribute without a usable prefix
+                // gets one via `attr_overrides` (see `plan_element_namespaces`).
+                for (attr, override_name) in elem.attributes.iter().zip(attr_overrides.iter()) {
                     out.write_char(' ')?;
-                    let raw_aname = attr.name.prefixed_name();
+                    let raw_aname = match override_name {
+                        Some(name) => Cow::Borrowed(name.as_str()),
+                        None => attr.name.prefixed_name(),
+                    };
                     let aname = crate::writer::unique_safe_xml_qname(&raw_aname, &mut seen_attrs);
                     out.write_str(&aname)?;
                     out.write_str("=\"")?;
                     write_escaped_attr(out, &attr.value)?;
                     out.write_char('"')?;
                 }
+                // Child scope: the inherited scope extended with the bindings this
+                // element introduced (stored + synthesized).
+                let child_scope = NsScope {
+                    parent: Some(scope),
+                    local: &child_local,
+                };
                 let children = self.children(id);
                 if children.is_empty() {
                     if opts.expand_empty_elements {
@@ -1359,7 +1427,14 @@ impl<'a> Document<'a> {
                         out.write_char('\n')?;
                     }
                     for child in &children {
-                        self.write_node_to(*child, out, opts, depth + 1, element_only)?;
+                        self.write_node_to(
+                            *child,
+                            out,
+                            opts,
+                            depth + 1,
+                            element_only,
+                            &child_scope,
+                        )?;
                     }
                     if element_only {
                         write_indent(out, opts, depth)?;
@@ -1419,7 +1494,7 @@ impl<'a> Document<'a> {
             }
             Some(NodeKind::Document) => {
                 for child in self.children(id) {
-                    self.write_node_to(child, out, opts, depth, indent_self)?;
+                    self.write_node_to(child, out, opts, depth, indent_self, scope)?;
                 }
             }
             Some(NodeKind::Attribute(_, _)) => {
@@ -1429,6 +1504,178 @@ impl<'a> Document<'a> {
         }
         Ok(())
     }
+}
+
+/// A `(prefix, namespace_uri)` binding; an empty prefix is the default namespace.
+type NsDecl = (String, String);
+
+/// In-scope namespace bindings during serialization, modeled as a borrowed
+/// linked list of per-element frames so no cloning happens per element. Each
+/// frame's `local` holds the declarations introduced by one element. The `xml`
+/// prefix is always implicitly bound.
+struct NsScope<'a> {
+    parent: Option<&'a NsScope<'a>>,
+    local: &'a [NsDecl],
+}
+
+impl<'a> NsScope<'a> {
+    /// Resolve a prefix to its namespace URI in scope. Returns `Some("")` for an
+    /// explicitly undeclared default namespace, `None` if the prefix is unbound.
+    fn resolve(&self, prefix: &str) -> Option<&str> {
+        if prefix == "xml" {
+            return Some(crate::namespace::XML_NAMESPACE);
+        }
+        let mut cur = Some(self);
+        while let Some(s) = cur {
+            for (p, u) in s.local.iter().rev() {
+                if p == prefix {
+                    return Some(u.as_str());
+                }
+            }
+            cur = s.parent;
+        }
+        None
+    }
+
+    /// Find a non-empty prefix currently bound to `uri`, respecting shadowing
+    /// (the innermost binding for each prefix wins).
+    fn prefix_for(&self, uri: &str) -> Option<String> {
+        let mut seen: Vec<String> = Vec::new();
+        let mut cur = Some(self);
+        while let Some(s) = cur {
+            for (p, u) in s.local.iter().rev() {
+                if seen.iter().any(|x| x == p) {
+                    continue;
+                }
+                seen.push(p.clone());
+                if !p.is_empty() && u == uri {
+                    return Some(p.clone());
+                }
+            }
+            cur = s.parent;
+        }
+        None
+    }
+}
+
+/// Compute the namespace declarations a serialized element must emit so its own
+/// QName and its attributes' QNames resolve correctly under the inherited
+/// `scope`. Returns:
+/// - `synthesized` — declarations to emit *in addition to* the element's stored
+///   `namespace_declarations` (which are still emitted verbatim),
+/// - `attr_overrides` — a per-attribute display-name override, set only for a
+///   namespaced attribute that needs a prefix it does not carry, and
+/// - `child_local` — every binding (stored + synthesized) this element
+///   introduces, for building the child scope.
+///
+/// For a parsed document the stored declarations already satisfy every QName, so
+/// `synthesized` is empty and output is byte-identical to before.
+fn plan_element_namespaces(
+    elem: &Element,
+    scope: &NsScope,
+) -> (Vec<NsDecl>, Vec<Option<String>>, Vec<NsDecl>) {
+    let mut child_local: Vec<NsDecl> = elem
+        .namespace_declarations
+        .iter()
+        .map(|(p, u)| (p.to_string(), u.to_string()))
+        .collect();
+    let mut synthesized: Vec<NsDecl> = Vec::new();
+
+    // Resolve `prefix` against the inherited scope plus the bindings collected so
+    // far for this element.
+    let bound = |prefix: &str, local: &[NsDecl]| -> Option<String> {
+        let cur = NsScope {
+            parent: Some(scope),
+            local,
+        };
+        cur.resolve(prefix).map(|s| s.to_string())
+    };
+
+    // Element QName.
+    match (
+        elem.name.prefix.as_deref(),
+        elem.name.namespace_uri.as_deref(),
+    ) {
+        (None, None) => {
+            // Unprefixed element in no namespace: if a non-empty default
+            // namespace is in scope it would otherwise capture this element, so
+            // undeclare it with `xmlns=""`.
+            if matches!(bound("", &child_local).as_deref(), Some(d) if !d.is_empty()) {
+                synthesized.push((String::new(), String::new()));
+                child_local.push((String::new(), String::new()));
+            }
+        }
+        (Some(_), None) => { /* prefixed but no URI: leave the name as-is */ }
+        (Some("xml"), Some(_)) => { /* the xml prefix is implicitly bound */ }
+        (Some(p), Some(u)) => {
+            if bound(p, &child_local).as_deref() != Some(u) {
+                synthesized.push((p.to_string(), u.to_string()));
+                child_local.push((p.to_string(), u.to_string()));
+            }
+        }
+        (None, Some(u)) => {
+            if bound("", &child_local).as_deref() != Some(u) {
+                synthesized.push((String::new(), u.to_string()));
+                child_local.push((String::new(), u.to_string()));
+            }
+        }
+    }
+
+    // Attributes. An empty prefix never works for an attribute (attributes are
+    // not in the default namespace), so a namespaced-but-prefixless attribute is
+    // given a prefix.
+    let mut attr_overrides = Vec::with_capacity(elem.attributes.len());
+    for attr in &elem.attributes {
+        let override_name = match (
+            attr.name.prefix.as_deref(),
+            attr.name.namespace_uri.as_deref(),
+        ) {
+            (_, None) | (Some("xml"), Some(_)) => None,
+            (Some(p), Some(u)) => {
+                if bound(p, &child_local).as_deref() != Some(u) {
+                    synthesized.push((p.to_string(), u.to_string()));
+                    child_local.push((p.to_string(), u.to_string()));
+                }
+                None
+            }
+            (None, Some(u)) => {
+                let existing = {
+                    let cur = NsScope {
+                        parent: Some(scope),
+                        local: &child_local,
+                    };
+                    cur.prefix_for(u)
+                };
+                let pfx = match existing {
+                    Some(p) => p,
+                    None => {
+                        let mut n = 0usize;
+                        let p = loop {
+                            let cand = format!("ns{}", n);
+                            let unbound = {
+                                let cur = NsScope {
+                                    parent: Some(scope),
+                                    local: &child_local,
+                                };
+                                cur.resolve(&cand).is_none()
+                            };
+                            if unbound {
+                                break cand;
+                            }
+                            n += 1;
+                        };
+                        synthesized.push((p.clone(), u.to_string()));
+                        child_local.push((p.clone(), u.to_string()));
+                        p
+                    }
+                };
+                Some(format!("{}:{}", pfx, attr.name.local_name))
+            }
+        };
+        attr_overrides.push(override_name);
+    }
+
+    (synthesized, attr_overrides, child_local)
 }
 
 impl<'a> Default for Document<'a> {

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1292,7 +1292,7 @@ impl<'a> Document<'a> {
     /// including `id` itself), outermost-first. Used to seed fragment
     /// serialization so a namespace already declared on an enclosing element is
     /// treated as in-scope and not redundantly re-declared.
-    fn ancestor_ns_bindings(&self, id: NodeId) -> Vec<NsDecl> {
+    fn ancestor_ns_bindings(&self, id: NodeId) -> Vec<NsDecl<'_>> {
         let mut chain = Vec::new();
         let mut cur = self.parent(id);
         while let Some(p) = cur {
@@ -1304,7 +1304,7 @@ impl<'a> Document<'a> {
         for nid in chain {
             if let Some(NodeKind::Element(e)) = self.node_kind(nid) {
                 for (pfx, uri) in &e.namespace_declarations {
-                    binds.push((pfx.to_string(), uri.to_string()));
+                    binds.push((Cow::Borrowed(pfx.as_ref()), Cow::Borrowed(uri.as_ref())));
                 }
             }
         }
@@ -1358,7 +1358,7 @@ impl<'a> Document<'a> {
                     if child_local[i + 1..].iter().any(|(p, _)| p == prefix) {
                         continue; // shadowed by a later binding for the same prefix
                     }
-                    let (prefix, uri) = (prefix.as_str(), uri.as_str());
+                    let (prefix, uri) = (prefix.as_ref(), uri.as_ref());
                     if prefix.is_empty() {
                         // A default-namespace declaration has the fixed name
                         // `xmlns`, which cannot be disambiguated; skip a
@@ -1512,7 +1512,9 @@ impl<'a> Document<'a> {
 }
 
 /// A `(prefix, namespace_uri)` binding; an empty prefix is the default namespace.
-type NsDecl = (String, String);
+/// `Cow` so stored declarations can be borrowed from the element (no per-element
+/// allocation), while synthesized bindings own their strings.
+type NsDecl<'a> = (Cow<'a, str>, Cow<'a, str>);
 
 /// In-scope namespace bindings during serialization, modeled as a borrowed
 /// linked list of per-element frames so no cloning happens per element. Each
@@ -1520,7 +1522,7 @@ type NsDecl = (String, String);
 /// prefix is always implicitly bound.
 struct NsScope<'a> {
     parent: Option<&'a NsScope<'a>>,
-    local: &'a [NsDecl],
+    local: &'a [NsDecl<'a>],
 }
 
 impl<'a> NsScope<'a> {
@@ -1533,8 +1535,8 @@ impl<'a> NsScope<'a> {
         let mut cur = Some(self);
         while let Some(s) = cur {
             for (p, u) in s.local.iter().rev() {
-                if p == prefix {
-                    return Some(u.as_str());
+                if p.as_ref() == prefix {
+                    return Some(u.as_ref());
                 }
             }
             cur = s.parent;
@@ -1552,8 +1554,8 @@ impl<'a> NsScope<'a> {
         let mut cur = Some(self);
         while let Some(s) = cur {
             for (p, u) in s.local.iter().rev() {
-                if seen.insert(p.as_str()) && !p.is_empty() && u == uri {
-                    return Some(p.clone());
+                if seen.insert(p.as_ref()) && !p.is_empty() && u.as_ref() == uri {
+                    return Some(p.as_ref().to_string());
                 }
             }
             cur = s.parent;
@@ -1585,7 +1587,11 @@ fn alloc_ns_prefix(scope: &NsScope, child_local: &[NsDecl]) -> String {
 /// Return an existing non-empty prefix bound to `uri`, or allocate a fresh one
 /// and record a declaration for it in `child_local`. Used when a prefix is
 /// required (namespaced attribute) or when the desired prefix is unusable.
-fn prefix_for_or_alloc(scope: &NsScope, child_local: &mut Vec<NsDecl>, uri: &str) -> String {
+fn prefix_for_or_alloc<'e>(
+    scope: &NsScope,
+    child_local: &mut Vec<NsDecl<'e>>,
+    uri: &'e str,
+) -> String {
     let reuse = {
         let cur = NsScope {
             parent: Some(scope),
@@ -1597,7 +1603,7 @@ fn prefix_for_or_alloc(scope: &NsScope, child_local: &mut Vec<NsDecl>, uri: &str
         return p;
     }
     let p = alloc_ns_prefix(scope, child_local);
-    child_local.push((p.clone(), uri.to_string()));
+    child_local.push((Cow::Owned(p.clone()), Cow::Borrowed(uri)));
     p
 }
 
@@ -1607,11 +1613,11 @@ fn prefix_for_or_alloc(scope: &NsScope, child_local: &mut Vec<NsDecl>, uri: &str
 /// a *different* prefix — because `desired_prefix` is already declared on this
 /// same start tag bound to another URI and a start tag cannot carry two bindings
 /// for one prefix — or `None` when `desired_prefix` works as-is.
-fn ensure_binding(
+fn ensure_binding<'e>(
     scope: &NsScope,
-    child_local: &mut Vec<NsDecl>,
-    desired_prefix: &str,
-    uri: &str,
+    child_local: &mut Vec<NsDecl<'e>>,
+    desired_prefix: &'e str,
+    uri: &'e str,
 ) -> Option<String> {
     let current = {
         let cur = NsScope {
@@ -1623,10 +1629,13 @@ fn ensure_binding(
     if current.as_deref() == Some(uri) {
         return None; // already correctly bound (here or via an ancestor)
     }
-    if !child_local.iter().any(|(p, _)| p == desired_prefix) {
+    if !child_local
+        .iter()
+        .any(|(p, _)| p.as_ref() == desired_prefix)
+    {
         // Not declared on this element yet: declare it here, shadowing any
         // ancestor binding. The QName keeps its own prefix.
-        child_local.push((desired_prefix.to_string(), uri.to_string()));
+        child_local.push((Cow::Borrowed(desired_prefix), Cow::Borrowed(uri)));
         return None;
     }
     // Same-element conflict: `desired_prefix` is already bound here to a different
@@ -1640,24 +1649,27 @@ fn ensure_binding(
 /// QName and its attributes' QNames resolve correctly under the inherited
 /// `scope`. Returns:
 /// - `elem_name_override` — a replacement element tag name, set only when the
-///   element's own prefix collides with a stored declaration,
+///   element's own prefix collides with a stored declaration or is the reserved
+///   `xml` prefix used for a non-XML namespace,
 /// - `attr_overrides` — a per-attribute display-name override, set only for a
 ///   namespaced attribute that needs a prefix it does not carry (or whose prefix
-///   collides), and
+///   collides / is reserved), and
 /// - `child_local` — every binding (stored + synthesized) this element
 ///   introduces, in order; the serializer emits the last binding per prefix and
 ///   uses it as the child scope.
 ///
 /// For a parsed document the stored declarations already satisfy every QName, so
-/// nothing is synthesized and output is byte-identical to before.
-fn plan_element_namespaces(
-    elem: &Element,
+/// nothing is synthesized and output is byte-identical to before. Stored
+/// declarations are borrowed (not cloned), so a no-op plan allocates nothing.
+fn plan_element_namespaces<'e>(
+    elem: &'e Element,
     scope: &NsScope,
-) -> (Option<String>, Vec<Option<String>>, Vec<NsDecl>) {
-    let mut child_local: Vec<NsDecl> = elem
+) -> (Option<String>, Vec<Option<String>>, Vec<NsDecl<'e>>) {
+    let xml_ns = crate::namespace::XML_NAMESPACE;
+    let mut child_local: Vec<NsDecl<'e>> = elem
         .namespace_declarations
         .iter()
-        .map(|(p, u)| (p.to_string(), u.to_string()))
+        .map(|(p, u)| (Cow::Borrowed(p.as_ref()), Cow::Borrowed(u.as_ref())))
         .collect();
 
     // Element QName.
@@ -1677,12 +1689,21 @@ fn plan_element_namespaces(
                 cur.resolve("").map(|s| s.to_string())
             };
             if matches!(default_ns.as_deref(), Some(d) if !d.is_empty()) {
-                child_local.push((String::new(), String::new()));
+                child_local.push((Cow::Borrowed(""), Cow::Borrowed("")));
             }
             None
         }
         (Some(_), None) => None, // prefixed but no URI: leave the name as-is
-        (Some("xml"), Some(_)) => None, // the xml prefix is implicitly bound
+        // The XML namespace is bound to `xml` and only `xml`, and is never
+        // declared. Any other prefix (or none) for that URI is rewritten to
+        // `xml`; the `xml` prefix used for any other URI is reassigned, since it
+        // is reserved and cannot be rebound.
+        (Some("xml"), Some(u)) if u == xml_ns => None,
+        (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", elem.name.local_name)),
+        (Some("xml"), Some(u)) => {
+            let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
+            Some(format!("{}:{}", pfx, elem.name.local_name))
+        }
         (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, p, u)
             .map(|q| format!("{}:{}", q, elem.name.local_name)),
         (None, Some(u)) => ensure_binding(scope, &mut child_local, "", u)
@@ -1698,7 +1719,13 @@ fn plan_element_namespaces(
             attr.name.prefix.as_deref(),
             attr.name.namespace_uri.as_deref(),
         ) {
-            (_, None) | (Some("xml"), Some(_)) => None,
+            (_, None) => None,
+            (Some("xml"), Some(u)) if u == xml_ns => None,
+            (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", attr.name.local_name)),
+            (Some("xml"), Some(u)) => {
+                let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
+                Some(format!("{}:{}", pfx, attr.name.local_name))
+            }
             (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, p, u)
                 .map(|q| format!("{}:{}", q, attr.name.local_name)),
             (None, Some(u)) => {

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1354,8 +1354,15 @@ impl<'a> Document<'a> {
                 // Sanitized prefixes can also collide (two distinct invalid
                 // prefixes both collapse to `_`), which is disambiguated against
                 // names already emitted for this start tag so output re-parses.
+                //
+                // Precompute the last index per prefix so the "last binding wins"
+                // dedup is O(n) rather than O(n^2) in the number of bindings.
+                let mut last_idx: HashMap<&str, usize> = HashMap::with_capacity(child_local.len());
+                for (i, (prefix, _)) in child_local.iter().enumerate() {
+                    last_idx.insert(prefix.as_ref(), i);
+                }
                 for (i, (prefix, uri)) in child_local.iter().enumerate() {
-                    if child_local[i + 1..].iter().any(|(p, _)| p == prefix) {
+                    if last_idx.get(prefix.as_ref()) != Some(&i) {
                         continue; // shadowed by a later binding for the same prefix
                     }
                     let (prefix, uri) = (prefix.as_ref(), uri.as_ref());
@@ -1627,14 +1634,14 @@ fn ensure_binding<'e>(
     desired_prefix: &'e str,
     uri: &'e str,
 ) -> Option<String> {
-    let current = {
+    let already_bound = {
         let cur = NsScope {
             parent: Some(scope),
             local: child_local,
         };
-        cur.resolve(desired_prefix).map(|s| s.to_string())
+        cur.resolve(desired_prefix) == Some(uri)
     };
-    if current.as_deref() == Some(uri) {
+    if already_bound {
         return None; // already correctly bound (here or via an ancestor)
     }
     if !child_local
@@ -1709,14 +1716,15 @@ fn plan_element_namespaces<'e>(
         // is reserved and cannot be rebound.
         (Some("xml"), Some(u)) if u == xml_ns => None,
         (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", elem.name.local_name)),
-        // The `xmlns` prefix and the XMLNS namespace are reserved for namespace
-        // declarations. Emitting `xmlns`/`xmlns:*` as a literal element name
-        // would re-parse as a declaration, and the parser ignores any binding
-        // to the XMLNS namespace, so rebind to a fresh non-reserved prefix.
-        (_, Some(u)) if u == xmlns_ns => {
-            let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
-            Some(format!("{}:{}", pfx, elem.name.local_name))
-        }
+        // The XMLNS namespace cannot be bound to any prefix: the parser ignores
+        // every binding to it, so a synthesized `xmlns:nsN="...2000/xmlns/"`
+        // declaration would not be namespace-well-formed and would not re-parse.
+        // The namespace is unrepresentable, so drop it and serialize the bare
+        // local name (never emitting an `xmlns`/`xmlns:*` name).
+        (_, Some(u)) if u == xmlns_ns => Some(elem.name.local_name.to_string()),
+        // The reserved `xml`/`xmlns` prefixes bound to any *other* (representable)
+        // URI are rebound to a fresh non-reserved prefix; emitting them verbatim
+        // would re-parse as the XML namespace / as a declaration.
         (Some("xml"), Some(u)) | (Some("xmlns"), Some(u)) => {
             let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
             Some(format!("{}:{}", pfx, elem.name.local_name))
@@ -1739,13 +1747,13 @@ fn plan_element_namespaces<'e>(
             (_, None) => None,
             (Some("xml"), Some(u)) if u == xml_ns => None,
             (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", attr.name.local_name)),
-            // Reserved `xmlns` prefix / XMLNS namespace: see the element-name
-            // planning above. Rebind to a fresh non-reserved prefix so the
-            // attribute does not masquerade as a namespace declaration.
-            (_, Some(u)) if u == xmlns_ns => {
-                let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
-                Some(format!("{}:{}", pfx, attr.name.local_name))
-            }
+            // XMLNS namespace: unrepresentable (see the element-name planning
+            // above), so drop it and serialize the bare local name rather than
+            // emit a forbidden `xmlns:nsN="...2000/xmlns/"` declaration.
+            (_, Some(u)) if u == xmlns_ns => Some(attr.name.local_name.to_string()),
+            // Reserved `xml`/`xmlns` prefixes on a representable URI: rebind to a
+            // fresh non-reserved prefix so the attribute does not masquerade as a
+            // namespace declaration.
             (Some("xml"), Some(u)) | (Some("xmlns"), Some(u)) => {
                 let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
                 Some(format!("{}:{}", pfx, attr.name.local_name))

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1335,7 +1335,7 @@ impl<'a> Document<'a> {
                 // QName and its attributes' QNames resolve under the current
                 // scope (issue #2). For parsed documents the stored declarations
                 // already satisfy every QName, so nothing extra is emitted.
-                let (synthesized, elem_name_override, attr_overrides, child_local) =
+                let (elem_name_override, attr_overrides, child_local) =
                     plan_element_namespaces(elem, scope);
                 let raw_pname = match &elem_name_override {
                     Some(name) => Cow::Borrowed(name.as_str()),
@@ -1346,17 +1346,19 @@ impl<'a> Document<'a> {
                 // Track names already emitted for this start tag so sanitized
                 // programmatic attributes cannot collide into duplicate XML.
                 let mut seen_attrs = Vec::new();
-                // Namespace declarations. Sanitized prefixes can collide (two
-                // distinct invalid prefixes both collapse to `_`), which would
-                // emit duplicate `xmlns:_` attributes and produce not-well-formed
-                // output. Disambiguate the prefix against names already emitted
-                // for this start tag so the result always re-parses.
-                let declarations = elem
-                    .namespace_declarations
-                    .iter()
-                    .map(|(p, u)| (p.as_ref(), u.as_ref()))
-                    .chain(synthesized.iter().map(|(p, u)| (p.as_str(), u.as_str())));
-                for (prefix, uri) in declarations {
+                // Namespace declarations. `child_local` holds every binding this
+                // element introduces (stored + synthesized) in order; emit only
+                // the *last* binding per prefix so a synthesized override — e.g. an
+                // `xmlns=""` undeclaration — wins over a conflicting stored
+                // declaration instead of being dropped as a duplicate.
+                // Sanitized prefixes can also collide (two distinct invalid
+                // prefixes both collapse to `_`), which is disambiguated against
+                // names already emitted for this start tag so output re-parses.
+                for (i, (prefix, uri)) in child_local.iter().enumerate() {
+                    if child_local[i + 1..].iter().any(|(p, _)| p == prefix) {
+                        continue; // shadowed by a later binding for the same prefix
+                    }
+                    let (prefix, uri) = (prefix.as_str(), uri.as_str());
                     if prefix.is_empty() {
                         // A default-namespace declaration has the fixed name
                         // `xmlns`, which cannot be disambiguated; skip a
@@ -1581,14 +1583,9 @@ fn alloc_ns_prefix(scope: &NsScope, child_local: &[NsDecl]) -> String {
 }
 
 /// Return an existing non-empty prefix bound to `uri`, or allocate a fresh one
-/// and record a declaration for it. Used when a prefix is required (namespaced
-/// attribute) or when the desired prefix is unusable.
-fn prefix_for_or_alloc(
-    scope: &NsScope,
-    child_local: &mut Vec<NsDecl>,
-    synthesized: &mut Vec<NsDecl>,
-    uri: &str,
-) -> String {
+/// and record a declaration for it in `child_local`. Used when a prefix is
+/// required (namespaced attribute) or when the desired prefix is unusable.
+fn prefix_for_or_alloc(scope: &NsScope, child_local: &mut Vec<NsDecl>, uri: &str) -> String {
     let reuse = {
         let cur = NsScope {
             parent: Some(scope),
@@ -1601,20 +1598,18 @@ fn prefix_for_or_alloc(
     }
     let p = alloc_ns_prefix(scope, child_local);
     child_local.push((p.clone(), uri.to_string()));
-    synthesized.push((p.clone(), uri.to_string()));
     p
 }
 
 /// Ensure `desired_prefix` (empty string = default namespace) resolves to `uri`
-/// for this element, recording any declaration that must be emitted. Returns
-/// `Some(prefix)` when the QName must be rewritten to use a *different* prefix —
-/// because `desired_prefix` is already declared on this same start tag bound to
-/// another URI and a start tag cannot carry two bindings for one prefix — or
-/// `None` when `desired_prefix` works as-is.
+/// for this element, recording any declaration that must be emitted in
+/// `child_local`. Returns `Some(prefix)` when the QName must be rewritten to use
+/// a *different* prefix — because `desired_prefix` is already declared on this
+/// same start tag bound to another URI and a start tag cannot carry two bindings
+/// for one prefix — or `None` when `desired_prefix` works as-is.
 fn ensure_binding(
     scope: &NsScope,
     child_local: &mut Vec<NsDecl>,
-    synthesized: &mut Vec<NsDecl>,
     desired_prefix: &str,
     uri: &str,
 ) -> Option<String> {
@@ -1632,46 +1627,38 @@ fn ensure_binding(
         // Not declared on this element yet: declare it here, shadowing any
         // ancestor binding. The QName keeps its own prefix.
         child_local.push((desired_prefix.to_string(), uri.to_string()));
-        synthesized.push((desired_prefix.to_string(), uri.to_string()));
         return None;
     }
     // Same-element conflict: `desired_prefix` is already bound here to a different
     // URI and cannot be redeclared, so bind `uri` to a different prefix and
     // rewrite the QName to use it (otherwise the QName would silently resolve to
     // the colliding declaration).
-    Some(prefix_for_or_alloc(scope, child_local, synthesized, uri))
+    Some(prefix_for_or_alloc(scope, child_local, uri))
 }
 
-/// Compute the namespace declarations a serialized element must emit so its own
+/// Compute the namespace bindings a serialized element introduces so its own
 /// QName and its attributes' QNames resolve correctly under the inherited
 /// `scope`. Returns:
-/// - `synthesized` — declarations to emit *in addition to* the element's stored
-///   `namespace_declarations` (which are still emitted verbatim),
 /// - `elem_name_override` — a replacement element tag name, set only when the
 ///   element's own prefix collides with a stored declaration,
 /// - `attr_overrides` — a per-attribute display-name override, set only for a
 ///   namespaced attribute that needs a prefix it does not carry (or whose prefix
 ///   collides), and
 /// - `child_local` — every binding (stored + synthesized) this element
-///   introduces, for building the child scope.
+///   introduces, in order; the serializer emits the last binding per prefix and
+///   uses it as the child scope.
 ///
 /// For a parsed document the stored declarations already satisfy every QName, so
-/// `synthesized` is empty and output is byte-identical to before.
+/// nothing is synthesized and output is byte-identical to before.
 fn plan_element_namespaces(
     elem: &Element,
     scope: &NsScope,
-) -> (
-    Vec<NsDecl>,
-    Option<String>,
-    Vec<Option<String>>,
-    Vec<NsDecl>,
-) {
+) -> (Option<String>, Vec<Option<String>>, Vec<NsDecl>) {
     let mut child_local: Vec<NsDecl> = elem
         .namespace_declarations
         .iter()
         .map(|(p, u)| (p.to_string(), u.to_string()))
         .collect();
-    let mut synthesized: Vec<NsDecl> = Vec::new();
 
     // Element QName.
     let elem_name_override = match (
@@ -1690,16 +1677,15 @@ fn plan_element_namespaces(
                 cur.resolve("").map(|s| s.to_string())
             };
             if matches!(default_ns.as_deref(), Some(d) if !d.is_empty()) {
-                synthesized.push((String::new(), String::new()));
                 child_local.push((String::new(), String::new()));
             }
             None
         }
         (Some(_), None) => None, // prefixed but no URI: leave the name as-is
         (Some("xml"), Some(_)) => None, // the xml prefix is implicitly bound
-        (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, p, u)
+        (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, p, u)
             .map(|q| format!("{}:{}", q, elem.name.local_name)),
-        (None, Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, "", u)
+        (None, Some(u)) => ensure_binding(scope, &mut child_local, "", u)
             .map(|q| format!("{}:{}", q, elem.name.local_name)),
     };
 
@@ -1713,17 +1699,17 @@ fn plan_element_namespaces(
             attr.name.namespace_uri.as_deref(),
         ) {
             (_, None) | (Some("xml"), Some(_)) => None,
-            (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, &mut synthesized, p, u)
+            (Some(p), Some(u)) => ensure_binding(scope, &mut child_local, p, u)
                 .map(|q| format!("{}:{}", q, attr.name.local_name)),
             (None, Some(u)) => {
-                let pfx = prefix_for_or_alloc(scope, &mut child_local, &mut synthesized, u);
+                let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
                 Some(format!("{}:{}", pfx, attr.name.local_name))
             }
         };
         attr_overrides.push(override_name);
     }
 
-    (synthesized, elem_name_override, attr_overrides, child_local)
+    (elem_name_override, attr_overrides, child_local)
 }
 
 impl<'a> Default for Document<'a> {

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1770,14 +1770,25 @@ fn plan_element_namespaces<'e>(
             // are implicitly bound, so `xml:foo` would re-parse into the XML
             // namespace and `xmlns:foo` would be read as a namespace declaration,
             // changing the attribute's effective namespace.
-            (Some("xml"), None) | (Some("xmlns"), None) => Some(attr.name.local_name.to_string()),
+            (None, None) if attr.name.local_name.as_ref() == "xmlns" => Some("xmlns_".to_string()),
+            (Some("xml"), None) | (Some("xmlns"), None) => {
+                Some(if attr.name.local_name.as_ref() == "xmlns" {
+                    "xmlns_".to_string()
+                } else {
+                    attr.name.local_name.to_string()
+                })
+            }
             (_, None) => None,
             (Some("xml"), Some(u)) if u == xml_ns => None,
             (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", attr.name.local_name)),
             // XMLNS namespace: unrepresentable (see the element-name planning
             // above), so drop it and serialize the bare local name rather than
             // emit a forbidden `xmlns:nsN="...2000/xmlns/"` declaration.
-            (_, Some(u)) if u == xmlns_ns => Some(attr.name.local_name.to_string()),
+            (_, Some(u)) if u == xmlns_ns => Some(if attr.name.local_name.as_ref() == "xmlns" {
+                "xmlns_".to_string()
+            } else {
+                attr.name.local_name.to_string()
+            }),
             // Reserved `xml`/`xmlns` prefixes on a representable URI: rebind to a
             // fresh non-reserved prefix so the attribute does not masquerade as a
             // namespace declaration.

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1545,7 +1545,10 @@ impl<'a> NsScope<'a> {
     }
 
     /// Find a non-empty prefix currently bound to `uri`, respecting shadowing
-    /// (the innermost binding for each prefix wins).
+    /// (the innermost binding for each prefix wins). The reserved `xml` and
+    /// `xmlns` prefixes are never returned: reusing them for an arbitrary URI
+    /// would defeat the "reserved prefixes are never rebound" guarantee and
+    /// produce output that re-parses into the wrong namespace.
     fn prefix_for(&self, uri: &str) -> Option<String> {
         // Track seen prefixes by reference (no cloning); the innermost binding
         // for each prefix is its effective one, so a prefix seen earlier shadows
@@ -1554,7 +1557,12 @@ impl<'a> NsScope<'a> {
         let mut cur = Some(self);
         while let Some(s) = cur {
             for (p, u) in s.local.iter().rev() {
-                if seen.insert(p.as_ref()) && !p.is_empty() && u.as_ref() == uri {
+                if seen.insert(p.as_ref())
+                    && !p.is_empty()
+                    && p.as_ref() != "xml"
+                    && p.as_ref() != "xmlns"
+                    && u.as_ref() == uri
+                {
                     return Some(p.as_ref().to_string());
                 }
             }
@@ -1666,6 +1674,7 @@ fn plan_element_namespaces<'e>(
     scope: &NsScope,
 ) -> (Option<String>, Vec<Option<String>>, Vec<NsDecl<'e>>) {
     let xml_ns = crate::namespace::XML_NAMESPACE;
+    let xmlns_ns = crate::namespace::XMLNS_NAMESPACE;
     let mut child_local: Vec<NsDecl<'e>> = elem
         .namespace_declarations
         .iter()
@@ -1700,7 +1709,15 @@ fn plan_element_namespaces<'e>(
         // is reserved and cannot be rebound.
         (Some("xml"), Some(u)) if u == xml_ns => None,
         (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", elem.name.local_name)),
-        (Some("xml"), Some(u)) => {
+        // The `xmlns` prefix and the XMLNS namespace are reserved for namespace
+        // declarations. Emitting `xmlns`/`xmlns:*` as a literal element name
+        // would re-parse as a declaration, and the parser ignores any binding
+        // to the XMLNS namespace, so rebind to a fresh non-reserved prefix.
+        (_, Some(u)) if u == xmlns_ns => {
+            let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
+            Some(format!("{}:{}", pfx, elem.name.local_name))
+        }
+        (Some("xml"), Some(u)) | (Some("xmlns"), Some(u)) => {
             let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
             Some(format!("{}:{}", pfx, elem.name.local_name))
         }
@@ -1722,7 +1739,14 @@ fn plan_element_namespaces<'e>(
             (_, None) => None,
             (Some("xml"), Some(u)) if u == xml_ns => None,
             (_, Some(u)) if u == xml_ns => Some(format!("xml:{}", attr.name.local_name)),
-            (Some("xml"), Some(u)) => {
+            // Reserved `xmlns` prefix / XMLNS namespace: see the element-name
+            // planning above. Rebind to a fresh non-reserved prefix so the
+            // attribute does not masquerade as a namespace declaration.
+            (_, Some(u)) if u == xmlns_ns => {
+                let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
+                Some(format!("{}:{}", pfx, attr.name.local_name))
+            }
+            (Some("xml"), Some(u)) | (Some("xmlns"), Some(u)) => {
                 let pfx = prefix_for_or_alloc(scope, &mut child_local, u);
                 Some(format!("{}:{}", pfx, attr.name.local_name))
             }

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -956,9 +956,12 @@ fn ns_two_attributes_same_prefix_distinct_uris() {
 #[test]
 fn ns_xmlns_prefix_does_not_masquerade_as_declaration() {
     use uppsala::{Document, QName};
-    // The `xmlns` prefix is reserved for namespace declarations. A programmatic
-    // QName using prefix `xmlns` must not serialize as `xmlns:...`, which the
-    // parser would treat as a namespace declaration rather than an element name.
+    // The `xmlns` prefix is reserved and implicitly bound to the XMLNS
+    // namespace. A programmatic QName using prefix `xmlns` must not serialize as
+    // `xmlns:...`: an `xmlns:`-prefixed element name would re-parse bound to the
+    // XMLNS namespace (silently losing `urn:custom`), and an `xmlns`/`xmlns:*`
+    // attribute would be parsed as a namespace declaration instead of an
+    // attribute.
     let mut doc = Document::new();
     let el = doc.create_element(QName::full("xmlns", "urn:custom", "Foo"));
     doc.append_child(doc.root(), el);
@@ -1045,4 +1048,55 @@ fn ns_xmlns_namespace_attribute_is_dropped_on_serialization() {
     let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
     let root = re.element(re.document_element().unwrap()).unwrap();
     assert_eq!(root.get_attribute("a"), Some("v"), "{out}");
+}
+
+#[test]
+fn ns_reserved_element_prefix_without_uri_is_stripped() {
+    use uppsala::{Document, QName};
+    // A QName carrying a reserved prefix but no namespace URI must not serialize
+    // verbatim: `xml`/`xmlns` are implicitly bound, so `xml:Foo`/`xmlns:Foo`
+    // would re-parse into the XML/XMLNS namespace, silently changing the
+    // element's namespace. The bare local name is emitted instead.
+    for prefix in ["xml", "xmlns"] {
+        let mut doc = Document::new();
+        let mut name = QName::local("Foo");
+        name.prefix = Some(std::borrow::Cow::Borrowed(prefix));
+        let el = doc.create_element(name);
+        doc.append_child(doc.root(), el);
+        let out = doc.to_xml();
+        assert_eq!(
+            out, "<Foo/>",
+            "reserved prefix {prefix} not stripped: {out}"
+        );
+        let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+        let root = re.element(re.document_element().unwrap()).unwrap();
+        assert!(
+            root.name.namespace_uri.is_none(),
+            "spurious namespace: {out}"
+        );
+    }
+}
+
+#[test]
+fn ns_reserved_attribute_prefix_without_uri_is_stripped() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    for prefix in ["xml", "xmlns"] {
+        let mut doc = Document::new();
+        let el = doc.create_element(QName::local("r"));
+        doc.append_child(doc.root(), el);
+        let mut name = QName::local("a");
+        name.prefix = Some(Cow::Borrowed(prefix));
+        doc.element_mut(el)
+            .unwrap()
+            .set_attribute(name, Cow::Borrowed("v"));
+        let out = doc.to_xml();
+        assert_eq!(
+            out, r#"<r a="v"/>"#,
+            "reserved prefix {prefix} not stripped: {out}"
+        );
+        let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+        let root = re.element(re.document_element().unwrap()).unwrap();
+        assert_eq!(root.get_attribute("a"), Some("v"), "{out}");
+    }
 }

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -997,17 +997,52 @@ fn ns_xmlns_prefixed_attribute_does_not_masquerade_as_declaration() {
 }
 
 #[test]
-fn ns_xmlns_namespace_uri_is_reassigned_to_nonreserved_prefix() {
+fn ns_xmlns_namespace_uri_is_dropped_on_serialization() {
     use uppsala::{Document, QName};
-    // A QName carrying the reserved XMLNS namespace URI must not serialize with
-    // the `xmlns` prefix (which the parser reads as a declaration). It is rebound
-    // to a fresh, non-reserved prefix.
+    // The XMLNS namespace cannot be bound to any prefix (the parser ignores such
+    // bindings), so a QName carrying it is serialized without a namespace rather
+    // than emitting a forbidden `xmlns:nsN="...2000/xmlns/"` declaration that
+    // would not be namespace-well-formed.
     let mut doc = Document::new();
     let el = doc.create_element(QName::full("p", "http://www.w3.org/2000/xmlns/", "Foo"));
     doc.append_child(doc.root(), el);
     let out = doc.to_xml();
     assert!(
-        !out.contains("<xmlns:") && !out.starts_with("<xmlns"),
+        !out.contains("2000/xmlns"),
+        "forbidden XMLNS binding emitted: {out}"
+    );
+    assert!(
+        !out.contains("xmlns:") && !out.starts_with("<xmlns"),
         "XMLNS namespace serialized as a declaration: {out}"
     );
+    // Output must be well-formed and re-parse with the namespace dropped.
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.document_element().unwrap();
+    assert_eq!(
+        re.element(root).unwrap().name.local_name.as_ref(),
+        "Foo",
+        "{out}"
+    );
+}
+
+#[test]
+fn ns_xmlns_namespace_attribute_is_dropped_on_serialization() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el).unwrap().set_attribute(
+        QName::full("p", "http://www.w3.org/2000/xmlns/", "a"),
+        Cow::Borrowed("v"),
+    );
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("2000/xmlns") && !out.contains("xmlns:"),
+        "forbidden XMLNS binding emitted on attribute: {out}"
+    );
+    // Well-formed and re-parses; the bare attribute survives without a namespace.
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.get_attribute("a"), Some("v"), "{out}");
 }

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -846,6 +846,32 @@ fn ns_same_prefix_conflict_does_not_misbind() {
 }
 
 #[test]
+fn ns_stored_default_does_not_capture_no_namespace_element() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // The element is in no namespace but carries a stored default-namespace
+    // declaration (xmlns="urn:x"). Emitting that stored declaration would put the
+    // element in urn:x, so the synthesized `xmlns=""` undeclaration must win and
+    // the stored default must be suppressed.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("Foo"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el)
+        .unwrap()
+        .namespace_declarations
+        .push((Cow::Borrowed(""), Cow::Borrowed("urn:x")));
+
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<Foo xmlns=""/>"#);
+    let re = uppsala::parse(&out).unwrap();
+    let root = re.document_element().unwrap();
+    assert!(
+        re.element(root).unwrap().name.namespace_uri.is_none(),
+        "element wrongly captured by stored default namespace: {out}"
+    );
+}
+
+#[test]
 fn ns_two_attributes_same_prefix_distinct_uris() {
     use std::borrow::Cow;
     use uppsala::{Document, QName};

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -812,3 +812,56 @@ fn ns_parsed_document_roundtrips_byte_identical() {
     let doc = uppsala::parse(xml).unwrap();
     assert_eq!(doc.to_xml(), xml);
 }
+
+#[test]
+fn ns_same_prefix_conflict_does_not_misbind() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // The element carries a stored declaration `p -> urn:old`, but its QName uses
+    // prefix `p` bound to `urn:new`. A start tag cannot declare `p` twice, so the
+    // element name must be rewritten to a fresh prefix that is bound to `urn:new`
+    // — otherwise `p:Foo` would silently resolve to `urn:old`.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("p", "urn:new", "Foo"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el)
+        .unwrap()
+        .namespace_declarations
+        .push((Cow::Borrowed("p"), Cow::Borrowed("urn:old")));
+
+    let out = doc.to_xml();
+    // Output must re-parse and the element must actually be in urn:new.
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.document_element().unwrap();
+    assert_eq!(
+        re.element(root).unwrap().name.namespace_uri.as_deref(),
+        Some("urn:new"),
+        "element silently re-bound to the wrong namespace: {out}"
+    );
+    // The conflicting stored prefix is preserved for any descendants that use it.
+    assert!(
+        out.contains(r#"xmlns:p="urn:old""#),
+        "stored declaration dropped: {out}"
+    );
+}
+
+#[test]
+fn ns_two_attributes_same_prefix_distinct_uris() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // Two attributes both want prefix `p` but for different URIs; only one can
+    // keep `p`, the other must be rewritten so both resolve correctly.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("Foo"));
+    doc.append_child(doc.root(), el);
+    {
+        let e = doc.element_mut(el).unwrap();
+        e.set_attribute(QName::full("p", "urn:a", "one"), Cow::Borrowed("1"));
+        e.set_attribute(QName::full("p", "urn:b", "two"), Cow::Borrowed("2"));
+    }
+    let out = doc.to_xml();
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.get_attribute_ns("urn:a", "one"), Some("1"), "{out}");
+    assert_eq!(root.get_attribute_ns("urn:b", "two"), Some("2"), "{out}");
+}

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -1051,6 +1051,36 @@ fn ns_xmlns_namespace_attribute_is_dropped_on_serialization() {
 }
 
 #[test]
+fn ns_stored_reserved_declarations_are_filtered() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // Stored namespace declarations holding reserved bindings (the `xmlns`
+    // prefix, the `xml` prefix bound to a non-XML URI, or any prefix bound to the
+    // XMLNS namespace) must not be emitted: the parser's resolver ignores them, so
+    // serializing them would produce namespace-not-well-formed output.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    {
+        let e = doc.element_mut(el).unwrap();
+        e.namespace_declarations
+            .push((Cow::Borrowed("xmlns"), Cow::Borrowed("urn:bad")));
+        e.namespace_declarations
+            .push((Cow::Borrowed("xml"), Cow::Borrowed("urn:notxml")));
+        e.namespace_declarations.push((
+            Cow::Borrowed("p"),
+            Cow::Borrowed("http://www.w3.org/2000/xmlns/"),
+        ));
+    }
+    let out = doc.to_xml();
+    assert_eq!(out, "<r/>", "reserved declarations were emitted: {out}");
+    assert!(
+        uppsala::parse(&out).is_ok(),
+        "output not well-formed: {out}"
+    );
+}
+
+#[test]
 fn ns_reserved_element_prefix_without_uri_is_stripped() {
     use uppsala::{Document, QName};
     // A QName carrying a reserved prefix but no namespace URI must not serialize

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -1081,6 +1081,36 @@ fn ns_stored_reserved_declarations_are_filtered() {
 }
 
 #[test]
+fn ns_invalid_inscope_prefix_is_not_reused() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // An in-scope prefix that is not a valid XML NCName must not be reused for a
+    // namespaced-but-prefixless QName: doing so would yield a name like
+    // `bad prefix:attr` that sanitizes to `_` (dropping the local name). A fresh
+    // valid prefix is allocated instead, so the attribute still re-parses into its
+    // namespace.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    {
+        let e = doc.element_mut(el).unwrap();
+        // Stored declaration with an invalid (non-NCName) prefix bound to urn:x.
+        e.namespace_declarations
+            .push((Cow::Borrowed("bad prefix"), Cow::Borrowed("urn:x")));
+        // Prefixless attribute in the same namespace would trigger prefix reuse.
+        e.set_attribute(QName::with_namespace("urn:x", "attr"), Cow::Borrowed("v"));
+    }
+    let out = doc.to_xml();
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(
+        root.get_attribute_ns("urn:x", "attr"),
+        Some("v"),
+        "attribute lost its namespace via invalid prefix reuse: {out}"
+    );
+}
+
+#[test]
 fn ns_reserved_element_prefix_without_uri_is_stripped() {
     use uppsala::{Document, QName};
     // A QName carrying a reserved prefix but no namespace URI must not serialize

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -952,3 +952,62 @@ fn ns_two_attributes_same_prefix_distinct_uris() {
     assert_eq!(root.get_attribute_ns("urn:a", "one"), Some("1"), "{out}");
     assert_eq!(root.get_attribute_ns("urn:b", "two"), Some("2"), "{out}");
 }
+
+#[test]
+fn ns_xmlns_prefix_does_not_masquerade_as_declaration() {
+    use uppsala::{Document, QName};
+    // The `xmlns` prefix is reserved for namespace declarations. A programmatic
+    // QName using prefix `xmlns` must not serialize as `xmlns:...`, which the
+    // parser would treat as a namespace declaration rather than an element name.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("xmlns", "urn:custom", "Foo"));
+    doc.append_child(doc.root(), el);
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("<xmlns:Foo"),
+        "reserved xmlns prefix misused as element name: {out}"
+    );
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.document_element().unwrap();
+    assert_eq!(
+        re.element(root).unwrap().name.namespace_uri.as_deref(),
+        Some("urn:custom"),
+        "element silently lost its namespace: {out}"
+    );
+}
+
+#[test]
+fn ns_xmlns_prefixed_attribute_does_not_masquerade_as_declaration() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el)
+        .unwrap()
+        .set_attribute(QName::full("xmlns", "urn:custom", "a"), Cow::Borrowed("v"));
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("xmlns:a="),
+        "reserved xmlns prefix misused as attribute name: {out}"
+    );
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.get_attribute_ns("urn:custom", "a"), Some("v"), "{out}");
+}
+
+#[test]
+fn ns_xmlns_namespace_uri_is_reassigned_to_nonreserved_prefix() {
+    use uppsala::{Document, QName};
+    // A QName carrying the reserved XMLNS namespace URI must not serialize with
+    // the `xmlns` prefix (which the parser reads as a declaration). It is rebound
+    // to a fresh, non-reserved prefix.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("p", "http://www.w3.org/2000/xmlns/", "Foo"));
+    doc.append_child(doc.root(), el);
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("<xmlns:") && !out.starts_with("<xmlns"),
+        "XMLNS namespace serialized as a declaration: {out}"
+    );
+}

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -668,3 +668,147 @@ fn write_to_with_pretty_options() {
     let result = String::from_utf8(buf).unwrap();
     assert_eq!(result, "<root>\n  <a/>\n  <b/>\n</root>\n");
 }
+
+// ─── Namespace-aware serialization (issue #2) ────────────────────────────────
+//
+// Programmatically-built elements carry a namespace URI on their QName but no
+// stored `xmlns` declaration. Serialization must synthesize the declarations
+// needed for the output to be namespace-well-formed, while leaving parsed
+// documents byte-identical.
+
+#[test]
+fn ns_prefixless_element_emits_default_declaration() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::with_namespace("urn:example", "Foo"));
+    doc.append_child(doc.root(), el);
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<Foo xmlns="urn:example"/>"#);
+    // Output must re-parse and preserve the namespace.
+    let re = uppsala::parse(&out).unwrap();
+    let root = re.document_element().unwrap();
+    assert!(re
+        .element(root)
+        .unwrap()
+        .matches_name_ns("urn:example", "Foo"));
+}
+
+#[test]
+fn ns_prefixed_element_emits_prefix_declaration() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("p", "urn:foo", "Foo"));
+    doc.append_child(doc.root(), el);
+    assert_eq!(doc.to_xml(), r#"<p:Foo xmlns:p="urn:foo"/>"#);
+    assert!(uppsala::parse(&doc.to_xml()).is_ok());
+}
+
+#[test]
+fn ns_child_inherits_without_redeclaring() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let parent = doc.create_element(QName::full("p", "urn:foo", "Parent"));
+    doc.append_child(doc.root(), parent);
+    let child = doc.create_element(QName::full("p", "urn:foo", "Child"));
+    doc.append_child(parent, child);
+    // The child reuses the in-scope binding rather than re-declaring it.
+    assert_eq!(
+        doc.to_xml(),
+        r#"<p:Parent xmlns:p="urn:foo"><p:Child/></p:Parent>"#
+    );
+}
+
+#[test]
+fn ns_nested_distinct_namespaces_each_declared() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let parent = doc.create_element(QName::full("a", "urn:a", "Parent"));
+    doc.append_child(doc.root(), parent);
+    let child = doc.create_element(QName::full("b", "urn:b", "Child"));
+    doc.append_child(parent, child);
+    assert_eq!(
+        doc.to_xml(),
+        r#"<a:Parent xmlns:a="urn:a"><b:Child xmlns:b="urn:b"/></a:Parent>"#
+    );
+}
+
+#[test]
+fn ns_attribute_with_prefix_declared() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("Foo"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el)
+        .unwrap()
+        .set_attribute(QName::full("x", "urn:x", "attr"), Cow::Borrowed("v"));
+    assert_eq!(doc.to_xml(), r#"<Foo xmlns:x="urn:x" x:attr="v"/>"#);
+    assert!(uppsala::parse(&doc.to_xml()).is_ok());
+}
+
+#[test]
+fn ns_attribute_without_prefix_gets_synthetic_prefix() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("Foo"));
+    doc.append_child(doc.root(), el);
+    // A namespaced attribute with no prefix cannot use the default namespace, so
+    // serialization allocates one.
+    doc.element_mut(el)
+        .unwrap()
+        .set_attribute(QName::with_namespace("urn:x", "attr"), Cow::Borrowed("v"));
+    let out = doc.to_xml();
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.document_element().unwrap();
+    assert_eq!(
+        re.element(root).unwrap().get_attribute_ns("urn:x", "attr"),
+        Some("v"),
+        "attribute namespace lost on round-trip: {out}"
+    );
+}
+
+#[test]
+fn ns_no_namespace_child_undeclares_default() {
+    use uppsala::{Document, NodeKind, QName};
+    let mut doc = Document::new();
+    let parent = doc.create_element(QName::with_namespace("urn:p", "Parent"));
+    doc.append_child(doc.root(), parent);
+    let child = doc.create_element(QName::local("Child"));
+    doc.append_child(parent, child);
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<Parent xmlns="urn:p"><Child xmlns=""/></Parent>"#);
+    // The child must round-trip back to no namespace.
+    let re = uppsala::parse(&out).unwrap();
+    let proot = re.document_element().unwrap();
+    let pchild = re
+        .children(proot)
+        .into_iter()
+        .find(|&c| matches!(re.node_kind(c), Some(NodeKind::Element(_))))
+        .unwrap();
+    assert!(
+        re.element(pchild).unwrap().name.namespace_uri.is_none(),
+        "child should be in no namespace: {out}"
+    );
+}
+
+#[test]
+fn ns_fragment_serialization_is_self_contained() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let parent = doc.create_element(QName::full("p", "urn:foo", "Parent"));
+    doc.append_child(doc.root(), parent);
+    let child = doc.create_element(QName::full("p", "urn:foo", "Child"));
+    doc.append_child(parent, child);
+    // Serializing the child on its own declares the namespace it uses.
+    assert_eq!(doc.node_to_xml(child), r#"<p:Child xmlns:p="urn:foo"/>"#);
+}
+
+#[test]
+fn ns_parsed_document_roundtrips_byte_identical() {
+    // The synthesis path must be a no-op for parsed documents: stored
+    // declarations already satisfy every QName.
+    let xml = r#"<p:Foo xmlns:p="urn:foo" xmlns="urn:def"><p:Bar/><Baz/></p:Foo>"#;
+    let doc = uppsala::parse(xml).unwrap();
+    assert_eq!(doc.to_xml(), xml);
+}

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -872,6 +872,67 @@ fn ns_stored_default_does_not_capture_no_namespace_element() {
 }
 
 #[test]
+fn ns_xml_prefix_with_foreign_uri_is_reassigned() {
+    use uppsala::{Document, QName};
+    // The `xml` prefix is reserved and bound to the XML namespace. A QName that
+    // uses prefix `xml` for a *different* URI must not serialize as `xml:...`,
+    // which would silently re-bind it to the XML namespace on re-parse.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("xml", "urn:custom", "Foo"));
+    doc.append_child(doc.root(), el);
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("<xml:Foo"),
+        "reserved xml prefix misused: {out}"
+    );
+    let re = uppsala::parse(&out).unwrap();
+    let root = re.document_element().unwrap();
+    assert_eq!(
+        re.element(root).unwrap().name.namespace_uri.as_deref(),
+        Some("urn:custom"),
+        "element silently re-bound to the XML namespace: {out}"
+    );
+}
+
+#[test]
+fn ns_xml_namespace_uses_reserved_prefix_without_declaration() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    // The genuine XML namespace must serialize with the `xml` prefix and never be
+    // declared (it is implicitly bound).
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el).unwrap().set_attribute(
+        QName::full("xml", "http://www.w3.org/XML/1998/namespace", "lang"),
+        Cow::Borrowed("en"),
+    );
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<r xml:lang="en"/>"#);
+    assert!(uppsala::parse(&out).is_ok());
+}
+
+#[test]
+fn ns_xml_prefixed_attribute_with_foreign_uri_is_reassigned() {
+    use std::borrow::Cow;
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    doc.element_mut(el)
+        .unwrap()
+        .set_attribute(QName::full("xml", "urn:custom", "a"), Cow::Borrowed("v"));
+    let out = doc.to_xml();
+    assert!(
+        !out.contains("xml:a="),
+        "reserved xml prefix misused on attribute: {out}"
+    );
+    let re = uppsala::parse(&out).unwrap();
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.get_attribute_ns("urn:custom", "a"), Some("v"), "{out}");
+}
+
+#[test]
 fn ns_two_attributes_same_prefix_distinct_uris() {
     use std::borrow::Cow;
     use uppsala::{Document, QName};


### PR DESCRIPTION
Fixes #2, document serialization wrote QName prefixes and local names but only emitted the xmlns declarations stored in
Element::namespace_declarations, which are populated during parsing. Programmatically built QNames that carry a namespace_uri produced
unsound output: QName::with_namespace( "foo","Foo") serialized to <Foo/>
(namespace dropped) and QName::full("p","urn:foo","Foo") to <p:Foo/> (undeclared prefix). Fixes #2.

Make write_node_to namespace-aware using a borrowed NsScope stack (no per-element cloning). A new plan_element_namespaces computes, per element, the declarations that must be synthesized so the element's QName and each attribute's QName resolve under the in-scope bindings, emitted alongside the stored declarations:

- prefixed element        -> xmlns:prefix="uri"
- prefixless element      -> default xmlns="uri"
- namespaced attribute    -> declare its prefix, or allocate nsN when it
  has none (attributes cannot use the default namespace)
- no-namespace element under a default namespace -> xmlns=""
- the xml prefix is never declared
- bindings already in scope (inherited from an ancestor) are not
  re-declared

This is a no-op for parsed documents: their stored declarations already satisfy every QName, so output stays byte-identical. Full-document serialization seeds an empty root scope; node_to_xml fragments seed from the node's ancestor declarations, so parsed fragments are unchanged while programmatic fragments become self-contained.

Add 9 regression tests in serialization_conformance.rs covering prefixless/prefixed elements, inherited vs distinct namespaces, namespaced attributes (with prefix and synthetic prefix, round-tripped), default-namespace undeclaration, fragment self-containment, and a parsed-document byte-identical round-trip.