### PR TITLE
feat(parser): add opt-in forbid_dtd and forbid_entities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uppsala"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A pure Rust XML parser, DOM, namespace, XPath, and XSD validation library"
 license = "BSD-2-Clause"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -59,6 +59,13 @@ pub struct Parser {
     /// billion-laughs (exponential nesting) and quadratic-blowup (single
     /// large entity referenced many times) attacks.
     max_entity_expansion: usize,
+    /// When `true`, any `<!DOCTYPE` declaration is rejected at parse time
+    /// instead of being parsed. Off by default. See [`Parser::with_forbid_dtd`].
+    forbid_dtd: bool,
+    /// When `true`, `<!ENTITY>` declarations (general and parameter) inside a
+    /// DTD are rejected while the rest of the DTD is still parsed. Off by
+    /// default. See [`Parser::with_forbid_entities`].
+    forbid_entities: bool,
 }
 
 impl Parser {
@@ -69,6 +76,8 @@ impl Parser {
             namespace_aware: true,
             max_depth: DEFAULT_MAX_DEPTH,
             max_entity_expansion: DEFAULT_MAX_ENTITY_EXPANSION,
+            forbid_dtd: false,
+            forbid_entities: false,
         }
     }
 
@@ -79,6 +88,8 @@ impl Parser {
             namespace_aware,
             max_depth: DEFAULT_MAX_DEPTH,
             max_entity_expansion: DEFAULT_MAX_ENTITY_EXPANSION,
+            forbid_dtd: false,
+            forbid_entities: false,
         }
     }
 
@@ -93,6 +104,25 @@ impl Parser {
     /// call. Chains with other builder methods.
     pub fn with_max_entity_expansion(mut self, max_bytes: usize) -> Self {
         self.max_entity_expansion = max_bytes;
+        self
+    }
+
+    /// Reject any `<!DOCTYPE` declaration at parse time instead of parsing the
+    /// DTD internal subset. Off by default. Useful for security-sensitive
+    /// consumers (SAML, XML-DSig) where DTDs are never legitimate. Chains with
+    /// other builder methods.
+    pub fn with_forbid_dtd(mut self, forbid: bool) -> Self {
+        self.forbid_dtd = forbid;
+        self
+    }
+
+    /// Reject `<!ENTITY>` declarations (general and parameter) inside a DTD,
+    /// while still allowing the rest of the internal subset (`<!ELEMENT>`,
+    /// `<!ATTLIST>`, `<!NOTATION>`). Off by default; implied when
+    /// [`with_forbid_dtd`](Self::with_forbid_dtd) rejects the whole DOCTYPE.
+    /// Chains with other builder methods.
+    pub fn with_forbid_entities(mut self, forbid: bool) -> Self {
+        self.forbid_entities = forbid;
         self
     }
 
@@ -140,6 +170,8 @@ impl Parser {
             root_id,
             &mut entities,
             &mut entity_budget,
+            self.forbid_dtd,
+            self.forbid_entities,
         )?;
 
         // Parse document element and trailing misc
@@ -1233,6 +1265,8 @@ fn parse_misc<'a>(
     parent: NodeId,
     entities: &mut EntityMap,
     entity_budget: &mut usize,
+    forbid_dtd: bool,
+    forbid_entities: bool,
 ) -> XmlResult<()> {
     loop {
         cursor.skip_whitespace();
@@ -1252,7 +1286,14 @@ fn parse_misc<'a>(
             doc.set_byte_end_pos(id, cursor.pos);
             doc.append_child_unchecked(parent, id);
         } else if cursor.starts_with("<!DOCTYPE") {
-            parse_doctype(cursor, doc, entities, entity_budget)?;
+            if forbid_dtd {
+                return Err(XmlError::parse(
+                    "DOCTYPE declarations are not allowed (forbid_dtd)",
+                    cursor.line(),
+                    cursor.column(),
+                ));
+            }
+            parse_doctype(cursor, doc, entities, entity_budget, forbid_entities)?;
         } else {
             break;
         }
@@ -1270,6 +1311,7 @@ fn parse_doctype<'a>(
     doc: &mut Document<'a>,
     entities: &mut EntityMap,
     entity_budget: &mut usize,
+    forbid_entities: bool,
 ) -> XmlResult<()> {
     let start_pos = cursor.pos;
     cursor.expect("<!DOCTYPE")?;
@@ -1327,7 +1369,7 @@ fn parse_doctype<'a>(
     // Optional internal subset
     if cursor.peek() == Some('[') {
         cursor.advance_char();
-        parse_internal_subset(cursor, entities, entity_budget)?;
+        parse_internal_subset(cursor, entities, entity_budget, forbid_entities)?;
         cursor.expect("]")?;
         cursor.skip_whitespace();
     }
@@ -1424,6 +1466,7 @@ fn parse_internal_subset(
     cursor: &mut Cursor,
     entities: &mut EntityMap,
     entity_budget: &mut usize,
+    forbid_entities: bool,
 ) -> XmlResult<()> {
     loop {
         cursor.skip_whitespace();
@@ -1443,6 +1486,13 @@ fn parse_internal_subset(
         } else if cursor.starts_with("<!ATTLIST") {
             parse_attlist_decl(cursor, entities, entity_budget)?;
         } else if cursor.starts_with("<!ENTITY") {
+            if forbid_entities {
+                return Err(XmlError::parse(
+                    "Entity declarations are not allowed (forbid_entities)",
+                    cursor.line(),
+                    cursor.column(),
+                ));
+            }
             parse_entity_decl(cursor, entities)?;
         } else if cursor.starts_with("<!NOTATION") {
             parse_notation_decl(cursor)?;

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -11,7 +11,7 @@
 //!
 use std::time::{Duration, Instant};
 
-use uppsala::{parse, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
+use uppsala::{parse, Parser, XPathEvaluator, XmlWriter, XsdRegex, XsdValidator};
 
 // ─── Finding F-01 — Billion Laughs (entity expansion) ──────────────────
 
@@ -565,4 +565,81 @@ fn xpath_double_slash_blowup() {
         "XPath double-slash regression: query took {:?}",
         start.elapsed()
     );
+}
+
+// ─── Opt-in hardening — forbid_dtd / forbid_entities ───────────────────
+//
+// defusedxml-style switches. Both default off (the free `parse()` is
+// unchanged); when enabled the parser fails closed at the DOCTYPE / entity
+// declaration rather than parsing it.
+
+/// `forbid_dtd` rejects an external-ID DOCTYPE before parsing the DTD.
+#[test]
+fn forbid_dtd_rejects_external_doctype() {
+    let xml = r#"<!DOCTYPE r SYSTEM "r.dtd"><r/>"#;
+    assert!(parse(xml).is_ok(), "precondition: parses with the flag off");
+    let res = Parser::new().with_forbid_dtd(true).parse(xml);
+    assert!(res.is_err(), "forbid_dtd must reject the DOCTYPE");
+    assert!(
+        format!("{:?}", res.err()).contains("forbid_dtd"),
+        "error should mention forbid_dtd"
+    );
+}
+
+/// `forbid_dtd` rejects an internal-subset DOCTYPE (even entity-free).
+#[test]
+fn forbid_dtd_rejects_internal_subset() {
+    let xml = r#"<!DOCTYPE r [ <!ELEMENT r EMPTY> ]><r/>"#;
+    assert!(parse(xml).is_ok(), "precondition: parses with the flag off");
+    assert!(
+        Parser::new().with_forbid_dtd(true).parse(xml).is_err(),
+        "forbid_dtd must reject any DOCTYPE"
+    );
+}
+
+/// `forbid_dtd` leaves DTD-free documents untouched.
+#[test]
+fn forbid_dtd_accepts_dtd_free_document() {
+    assert!(
+        Parser::new().with_forbid_dtd(true).parse("<r/>").is_ok(),
+        "forbid_dtd must not affect documents without a DOCTYPE"
+    );
+}
+
+/// `forbid_entities` rejects general and parameter entity declarations.
+#[test]
+fn forbid_entities_rejects_entity_declarations() {
+    let general = r#"<!DOCTYPE r [ <!ENTITY x "y"> ]><r/>"#;
+    let parameter = r#"<!DOCTYPE r [ <!ENTITY % p "<!ELEMENT r EMPTY>"> ]><r/>"#;
+    for xml in [general, parameter] {
+        assert!(
+            parse(xml).is_ok(),
+            "precondition: parses with flag off: {xml}"
+        );
+        let res = Parser::new().with_forbid_entities(true).parse(xml);
+        assert!(res.is_err(), "forbid_entities must reject: {xml}");
+        assert!(
+            format!("{:?}", res.err()).contains("forbid_entities"),
+            "error should mention forbid_entities: {xml}"
+        );
+    }
+}
+
+/// `forbid_entities` is narrower than `forbid_dtd`: a DTD carrying only
+/// `<!ELEMENT>` / `<!ATTLIST>` is still accepted.
+#[test]
+fn forbid_entities_allows_entity_free_dtd() {
+    let xml = r#"<!DOCTYPE r [ <!ELEMENT r EMPTY> <!ATTLIST r a CDATA #IMPLIED> ]><r/>"#;
+    assert!(
+        Parser::new().with_forbid_entities(true).parse(xml).is_ok(),
+        "forbid_entities must allow an entity-free DTD"
+    );
+}
+
+/// Default parser (both flags off) still parses DOCTYPE + entities.
+#[test]
+fn default_parser_still_parses_dtd_and_entities() {
+    let xml = r#"<!DOCTYPE r [ <!ENTITY x "hi"> ]><r>&x;</r>"#;
+    assert!(parse(xml).is_ok(), "default behavior must be unchanged");
+    assert!(Parser::new().parse(xml).is_ok());
 }


### PR DESCRIPTION
Add two defusedxml-style hardening switches to Parser, both default off so the free parse()/parse_bytes() and all existing behavior are unchanged:

- with_forbid_dtd(true): reject any <!DOCTYPE at parse time, before the DTD internal subset is parsed.
- with_forbid_entities(true): reject <!ENTITY> declarations (general and parameter) while still allowing the rest of a DTD (<!ELEMENT>, <!ATTLIST>, <!NOTATION>).

forbid_dtd is checked at the <!DOCTYPE branch in parse_misc; forbid_entities is threaded through parse_doctype -> parse_internal_subset and checked at the <!ENTITY branch. Both fail closed via XmlError::parse, consistent with the existing max-depth rejection, and report the offending line/column.

These cover the last defusedxml defense uppsala lacked. External entities are already structurally unresolvable (no XXE/SSRF/file read) and billion-laughs / quadratic-blowup remain bounded by the entity-expansion byte budget, so forbid_external is not needed.

Add regression tests in tests/security_audit.rs (external/internal DOCTYPE rejection, general/parameter entity rejection, entity-free DTD still accepted, default-parser regression guard).