### PR TITLE
feat: declare_namespace helper + nullable xs:choice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uppsala"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A pure Rust XML parser, DOM, namespace, XPath, and XSD validation library"
 license = "BSD-2-Clause"

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -531,6 +531,44 @@ impl<'a> Document<'a> {
         )
     }
 
+    /// Declare a namespace binding on an element node.
+    ///
+    /// `prefix` is `None` (or `""`) for the default namespace. If the element
+    /// already declares `prefix`, its URI is updated in place; otherwise a new
+    /// declaration is appended. This writes to [`Element::namespace_declarations`]
+    /// — the proper home for `xmlns`/`xmlns:*` output — rather than adding an
+    /// attribute, so it serializes as a real namespace declaration.
+    ///
+    /// Returns `true` if `node` is an element (and the binding was recorded),
+    /// `false` otherwise. Note that the serializer still filters reserved
+    /// bindings (the `xmlns` prefix, `xml` bound to a non-XML URI, or any prefix
+    /// bound to the XMLNS namespace), so declaring those here is a no-op on output.
+    pub fn declare_namespace(
+        &mut self,
+        node: NodeId,
+        prefix: Option<&str>,
+        uri: impl Into<Cow<'a, str>>,
+    ) -> bool {
+        let prefix = prefix.unwrap_or("");
+        match self.element_mut(node) {
+            Some(el) => {
+                let uri = uri.into();
+                match el
+                    .namespace_declarations
+                    .iter_mut()
+                    .find(|(p, _)| p.as_ref() == prefix)
+                {
+                    Some(slot) => slot.1 = uri,
+                    None => el
+                        .namespace_declarations
+                        .push((Cow::Owned(prefix.to_string()), uri)),
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Create a new text node (not yet attached to the tree).
     pub fn create_text(&mut self, text: impl Into<Cow<'a, str>>) -> NodeId {
         self.alloc_node(NodeKind::Text(text.into()), 0)

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -559,9 +559,14 @@ impl<'a> Document<'a> {
                     .find(|(p, _)| p.as_ref() == prefix)
                 {
                     Some(slot) => slot.1 = uri,
-                    None => el
-                        .namespace_declarations
-                        .push((Cow::Owned(prefix.to_string()), uri)),
+                    None => {
+                        let prefix = if prefix.is_empty() {
+                            Cow::Borrowed("")
+                        } else {
+                            Cow::Owned(prefix.to_string())
+                        };
+                        el.namespace_declarations.push((prefix, uri));
+                    }
                 }
                 true
             }

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -1998,8 +1998,7 @@ mod tests {
         let root = doc.root();
         let err = eval
             .evaluate(&doc, root, &expr)
-            .err()
-            .expect("deep paren nesting must be rejected");
+            .expect_err("deep paren nesting must be rejected");
         assert!(
             format!("{}", err).contains("maximum depth"),
             "expected depth-cap error, got: {}",
@@ -2024,8 +2023,7 @@ mod tests {
         let root = doc.root();
         let err = eval
             .evaluate(&doc, root, &expr)
-            .err()
-            .expect("deep predicate nesting must be rejected");
+            .expect_err("deep predicate nesting must be rejected");
         assert!(
             format!("{}", err).contains("maximum depth"),
             "expected depth-cap error, got: {}",
@@ -2047,8 +2045,7 @@ mod tests {
         let root = doc.root();
         let err = eval
             .evaluate(&doc, root, &expr)
-            .err()
-            .expect("deep unary-minus chain must be rejected");
+            .expect_err("deep unary-minus chain must be rejected");
         assert!(
             format!("{}", err).contains("maximum depth"),
             "expected depth-cap error, got: {}",

--- a/src/xsd/tests.rs
+++ b/src/xsd/tests.rs
@@ -1,181 +1,178 @@
 //! Unit tests for the XSD validator.
 
-#[cfg(test)]
-mod tests {
-    use crate::parse;
-    use crate::xsd::types::XsdValidator;
+use crate::parse;
+use crate::xsd::types::XsdValidator;
 
-    #[test]
-    fn test_validate_string_element() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="root" type="xs:string"/>
-        </xs:schema>
-        "#;
-        let doc_xml = "<root>hello</root>";
+#[test]
+fn test_validate_string_element() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="root" type="xs:string"/>
+    </xs:schema>
+    "#;
+    let doc_xml = "<root>hello</root>";
 
-        let schema = parse(schema_xml).unwrap();
-        let doc = parse(doc_xml).unwrap();
+    let schema = parse(schema_xml).unwrap();
+    let doc = parse(doc_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+}
+
+#[test]
+fn test_validate_integer_valid() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="count" type="xs:integer"/>
+    </xs:schema>
+    "#;
+    let doc_xml = "<count>42</count>";
+
+    let schema = parse(schema_xml).unwrap();
+    let doc = parse(doc_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+}
+
+#[test]
+fn test_validate_integer_invalid() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="count" type="xs:integer"/>
+    </xs:schema>
+    "#;
+    let doc_xml = "<count>not-a-number</count>";
+
+    let schema = parse(schema_xml).unwrap();
+    let doc = parse(doc_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(!errors.is_empty());
+}
+
+#[test]
+fn test_validate_boolean() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="flag" type="xs:boolean"/>
+    </xs:schema>
+    "#;
+
+    let schema = parse(schema_xml).unwrap();
+
+    for val in &["true", "false", "1", "0"] {
+        let input = format!("<flag>{}</flag>", val);
+        let doc = parse(&input).unwrap();
         let validator = XsdValidator::from_schema(&schema).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(errors.is_empty(), "Errors: {:?}", errors);
+        assert!(validator.validate(&doc).is_empty(), "Failed for {}", val);
     }
 
-    #[test]
-    fn test_validate_integer_valid() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="count" type="xs:integer"/>
-        </xs:schema>
-        "#;
-        let doc_xml = "<count>42</count>";
+    let doc = parse("<flag>yes</flag>").unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    assert!(!validator.validate(&doc).is_empty());
+}
 
-        let schema = parse(schema_xml).unwrap();
-        let doc = parse(doc_xml).unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(errors.is_empty(), "Errors: {:?}", errors);
-    }
+#[test]
+fn test_validate_complex_type_sequence() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="person">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="name" type="xs:string"/>
+                    <xs:element name="age" type="xs:integer"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>
+    "#;
 
-    #[test]
-    fn test_validate_integer_invalid() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="count" type="xs:integer"/>
-        </xs:schema>
-        "#;
-        let doc_xml = "<count>not-a-number</count>";
+    let doc_xml = "<person><name>Alice</name><age>30</age></person>";
+    let schema = parse(schema_xml).unwrap();
+    let doc = parse(doc_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+}
 
-        let schema = parse(schema_xml).unwrap();
-        let doc = parse(doc_xml).unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(!errors.is_empty());
-    }
+#[test]
+fn test_validate_required_attribute() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="item">
+            <xs:complexType>
+                <xs:sequence/>
+                <xs:attribute name="id" type="xs:string" use="required"/>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>
+    "#;
 
-    #[test]
-    fn test_validate_boolean() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="flag" type="xs:boolean"/>
-        </xs:schema>
-        "#;
+    let schema = parse(schema_xml).unwrap();
 
-        let schema = parse(schema_xml).unwrap();
+    // Missing required attribute
+    let doc = parse("<item/>").unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(!errors.is_empty());
 
-        for val in &["true", "false", "1", "0"] {
-            let input = format!("<flag>{}</flag>", val);
-            let doc = parse(&input).unwrap();
-            let validator = XsdValidator::from_schema(&schema).unwrap();
-            assert!(validator.validate(&doc).is_empty(), "Failed for {}", val);
-        }
+    // With required attribute
+    let doc = parse(r#"<item id="123"/>"#).unwrap();
+    let errors = validator.validate(&doc);
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+}
 
-        let doc = parse("<flag>yes</flag>").unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-        assert!(!validator.validate(&doc).is_empty());
-    }
+#[test]
+fn test_validate_min_max_inclusive() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="score">
+            <xs:simpleType>
+                <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="100"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:element>
+    </xs:schema>
+    "#;
 
-    #[test]
-    fn test_validate_complex_type_sequence() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="person">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="name" type="xs:string"/>
-                        <xs:element name="age" type="xs:integer"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-        </xs:schema>
-        "#;
+    let schema = parse(schema_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
 
-        let doc_xml = "<person><name>Alice</name><age>30</age></person>";
-        let schema = parse(schema_xml).unwrap();
-        let doc = parse(doc_xml).unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(errors.is_empty(), "Errors: {:?}", errors);
-    }
+    let doc = parse("<score>50</score>").unwrap();
+    assert!(validator.validate(&doc).is_empty());
 
-    #[test]
-    fn test_validate_required_attribute() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="item">
-                <xs:complexType>
-                    <xs:sequence/>
-                    <xs:attribute name="id" type="xs:string" use="required"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:schema>
-        "#;
+    let doc = parse("<score>150</score>").unwrap();
+    assert!(!validator.validate(&doc).is_empty());
 
-        let schema = parse(schema_xml).unwrap();
+    let doc = parse("<score>-1</score>").unwrap();
+    assert!(!validator.validate(&doc).is_empty());
+}
 
-        // Missing required attribute
-        let doc = parse("<item/>").unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(!errors.is_empty());
+#[test]
+fn test_validate_enumeration() {
+    let schema_xml = r#"
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="color">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="red"/>
+                    <xs:enumeration value="green"/>
+                    <xs:enumeration value="blue"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:element>
+    </xs:schema>
+    "#;
 
-        // With required attribute
-        let doc = parse(r#"<item id="123"/>"#).unwrap();
-        let errors = validator.validate(&doc);
-        assert!(errors.is_empty(), "Errors: {:?}", errors);
-    }
+    let schema = parse(schema_xml).unwrap();
+    let validator = XsdValidator::from_schema(&schema).unwrap();
 
-    #[test]
-    fn test_validate_min_max_inclusive() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="score">
-                <xs:simpleType>
-                    <xs:restriction base="xs:integer">
-                        <xs:minInclusive value="0"/>
-                        <xs:maxInclusive value="100"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-        </xs:schema>
-        "#;
+    let doc = parse("<color>red</color>").unwrap();
+    assert!(validator.validate(&doc).is_empty());
 
-        let schema = parse(schema_xml).unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-
-        let doc = parse("<score>50</score>").unwrap();
-        assert!(validator.validate(&doc).is_empty());
-
-        let doc = parse("<score>150</score>").unwrap();
-        assert!(!validator.validate(&doc).is_empty());
-
-        let doc = parse("<score>-1</score>").unwrap();
-        assert!(!validator.validate(&doc).is_empty());
-    }
-
-    #[test]
-    fn test_validate_enumeration() {
-        let schema_xml = r#"
-        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="color">
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="red"/>
-                        <xs:enumeration value="green"/>
-                        <xs:enumeration value="blue"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-        </xs:schema>
-        "#;
-
-        let schema = parse(schema_xml).unwrap();
-        let validator = XsdValidator::from_schema(&schema).unwrap();
-
-        let doc = parse("<color>red</color>").unwrap();
-        assert!(validator.validate(&doc).is_empty());
-
-        let doc = parse("<color>yellow</color>").unwrap();
-        assert!(!validator.validate(&doc).is_empty());
-    }
+    let doc = parse("<color>yellow</color>").unwrap();
+    assert!(!validator.validate(&doc).is_empty());
 }

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -1606,9 +1606,10 @@ impl XsdValidator {
 
         if children.is_empty() {
             if compositor_min > 0 {
-                // Check if any particle allows 0 occurrences
-                let any_optional = particles.iter().any(|p| p.min_occurs == 0);
-                if !any_optional && !particles.is_empty() {
+                // The choice is satisfied with no content when any alternative is
+                // nullable (optional, or nullable through its own content).
+                let nullable = particles.iter().any(Self::particle_is_nullable);
+                if !nullable && !particles.is_empty() {
                     errors.push(ValidationError {
                         message: "Expected one of the choice alternatives".to_string(),
                         line: Some(doc.node_line(parent)),
@@ -1837,14 +1838,16 @@ impl XsdValidator {
             }
 
             if !matched_any {
-                // Current child doesn't match any alternative. A choice whose
-                // alternatives are all optional (every alternative has
-                // minOccurs=0) is *nullable*: it is satisfied by selecting an
-                // alternative and matching it zero times, so a non-matching child
-                // is not an error — the choice consumes nothing and an enclosing
-                // sequence continues with its next particle (e.g. KML's optional
+                // Current child doesn't match any alternative. A choice is
+                // *nullable* when at least one alternative can match the empty
+                // sequence — either an optional particle (minOccurs=0) or one
+                // whose content is itself nullable (e.g. a sequence of all
+                // optional particles). Selecting that alternative and matching it
+                // zero times satisfies the choice, so a non-matching child is not
+                // an error: the choice consumes nothing and an enclosing sequence
+                // continues with its next particle (e.g. KML's optional
                 // `Snippet|snippet` choice preceding the feature list).
-                let nullable = particles.iter().any(|p| p.min_occurs == 0);
+                let nullable = particles.iter().any(Self::particle_is_nullable);
                 if choice_reps < compositor_min && !nullable {
                     errors.push(ValidationError {
                         message: format!(
@@ -1862,9 +1865,11 @@ impl XsdValidator {
         }
 
         if choice_reps < compositor_min && child_idx == 0 && errors.is_empty() {
-            // No children matched and no error was emitted yet
-            let any_optional = particles.iter().any(|p| p.min_occurs == 0);
-            if !any_optional && !particles.is_empty() {
+            // No children matched and no error was emitted yet. The choice is
+            // satisfied without consuming anything when any alternative is
+            // nullable (see `particle_is_nullable`).
+            let nullable = particles.iter().any(Self::particle_is_nullable);
+            if !nullable && !particles.is_empty() {
                 errors.push(ValidationError {
                     message: "Expected one of the choice alternatives".to_string(),
                     line: Some(doc.node_line(parent)),
@@ -1874,6 +1879,25 @@ impl XsdValidator {
         }
 
         child_idx
+    }
+
+    /// Whether a particle can match the empty sequence (is *nullable*).
+    ///
+    /// A particle with `minOccurs=0` is always nullable. Otherwise nullability
+    /// depends on the kind:
+    /// - element / wildcard with `minOccurs>=1`: not nullable (must match one),
+    /// - sequence: nullable iff every sub-particle is nullable (an empty
+    ///   sequence is vacuously nullable),
+    /// - choice: nullable iff any sub-particle is nullable.
+    fn particle_is_nullable(particle: &Particle) -> bool {
+        if particle.min_occurs == 0 {
+            return true;
+        }
+        match &particle.kind {
+            ParticleKind::Element(_) | ParticleKind::Any { .. } => false,
+            ParticleKind::Sequence(subs) => subs.iter().all(Self::particle_is_nullable),
+            ParticleKind::Choice(subs) => subs.iter().any(Self::particle_is_nullable),
+        }
     }
 
     /// Validate an `xs:all` content model.

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -1837,8 +1837,15 @@ impl XsdValidator {
             }
 
             if !matched_any {
-                // Current child doesn't match any alternative
-                if choice_reps < compositor_min {
+                // Current child doesn't match any alternative. A choice whose
+                // alternatives are all optional (every alternative has
+                // minOccurs=0) is *nullable*: it is satisfied by selecting an
+                // alternative and matching it zero times, so a non-matching child
+                // is not an error — the choice consumes nothing and an enclosing
+                // sequence continues with its next particle (e.g. KML's optional
+                // `Snippet|snippet` choice preceding the feature list).
+                let nullable = particles.iter().any(|p| p.min_occurs == 0);
+                if choice_reps < compositor_min && !nullable {
                     errors.push(ValidationError {
                         message: format!(
                             "Element '{}' does not match any choice alternative",

--- a/tests/serialization_conformance.rs
+++ b/tests/serialization_conformance.rs
@@ -1160,3 +1160,51 @@ fn ns_reserved_attribute_prefix_without_uri_is_stripped() {
         assert_eq!(root.get_attribute("a"), Some("v"), "{out}");
     }
 }
+
+#[test]
+fn declare_namespace_emits_prefixed_declaration() {
+    use uppsala::{Document, QName};
+    // declare_namespace records a binding in namespace_declarations, so it
+    // serializes as a real xmlns:p="..." declaration (not an attribute).
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::full("p", "urn:ex", "Foo"));
+    doc.append_child(doc.root(), el);
+    assert!(doc.declare_namespace(el, Some("p"), "urn:ex"));
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<p:Foo xmlns:p="urn:ex"/>"#, "{out}");
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.name.namespace_uri.as_deref(), Some("urn:ex"), "{out}");
+}
+
+#[test]
+fn declare_namespace_default_on_element_in_that_namespace() {
+    use uppsala::{Document, QName};
+    // An element in `urn:ex` with a declared default namespace serializes as
+    // xmlns="urn:ex" (the lxml clark+nsmap shape), with the URI preserved.
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::with_namespace("urn:ex", "kml"));
+    doc.append_child(doc.root(), el);
+    assert!(doc.declare_namespace(el, None, "urn:ex"));
+    let out = doc.to_xml();
+    assert_eq!(out, r#"<kml xmlns="urn:ex"/>"#, "{out}");
+    let re = uppsala::parse(&out).unwrap_or_else(|e| panic!("must re-parse: {out} ({e})"));
+    let root = re.element(re.document_element().unwrap()).unwrap();
+    assert_eq!(root.name.namespace_uri.as_deref(), Some("urn:ex"), "{out}");
+}
+
+#[test]
+fn declare_namespace_upserts_existing_prefix() {
+    use uppsala::{Document, QName};
+    let mut doc = Document::new();
+    let el = doc.create_element(QName::local("r"));
+    doc.append_child(doc.root(), el);
+    doc.declare_namespace(el, Some("p"), "urn:old");
+    doc.declare_namespace(el, Some("p"), "urn:new"); // updates in place
+    let decls = &doc.element(el).unwrap().namespace_declarations;
+    assert_eq!(decls.len(), 1, "prefix p must not be duplicated");
+    assert_eq!(decls[0].1.as_ref(), "urn:new");
+    // Non-element node returns false.
+    let txt = doc.create_text("x");
+    assert!(!doc.declare_namespace(txt, Some("p"), "urn:x"));
+}

--- a/tests/w3c_xmlconf.rs
+++ b/tests/w3c_xmlconf.rs
@@ -283,17 +283,15 @@ fn w3c_xmltest_valid_standalone() {
             }
         };
 
-        let result = uppsala::parse_bytes(&bytes);
-        if result.is_ok() {
-            passed += 1;
-        } else {
-            failed += 1;
-            failures.push(format!(
-                "  {} ({}): expected success, got error: {}",
-                test.id,
-                test.uri,
-                result.unwrap_err()
-            ));
+        match uppsala::parse_bytes(&bytes) {
+            Ok(_) => passed += 1,
+            Err(err) => {
+                failed += 1;
+                failures.push(format!(
+                    "  {} ({}): expected success, got error: {}",
+                    test.id, test.uri, err
+                ));
+            }
         }
     }
 
@@ -360,17 +358,15 @@ fn w3c_xmltest_invalid_standalone() {
             }
         };
 
-        let result = uppsala::parse_bytes(&bytes);
-        if result.is_ok() {
-            passed += 1;
-        } else {
-            failed += 1;
-            failures.push(format!(
-                "  {} ({}): expected success (well-formed), got error: {}",
-                test.id,
-                test.uri,
-                result.unwrap_err()
-            ));
+        match uppsala::parse_bytes(&bytes) {
+            Ok(_) => passed += 1,
+            Err(err) => {
+                failed += 1;
+                failures.push(format!(
+                    "  {} ({}): expected success (well-formed), got error: {}",
+                    test.id, test.uri, err
+                ));
+            }
         }
     }
 

--- a/tests/w3c_xsts.rs
+++ b/tests/w3c_xsts.rs
@@ -352,7 +352,7 @@ fn xsts_nist_datatypes() {
             }
         }
         let mut breakdown: Vec<_> = by_type.into_iter().collect();
-        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
+        breakdown.sort_by_key(|b| std::cmp::Reverse(b.1));
         println!("\nFailure breakdown by type:");
         for (dtype, count) in &breakdown {
             println!("  {:>5} {}", count, dtype);

--- a/tests/xsd_conformance.rs
+++ b/tests/xsd_conformance.rs
@@ -615,3 +615,95 @@ fn xsd_inline_restriction_over_derived_list_enforces_item_facets() {
     // Item pattern enforced transitively through the inline restriction.
     assert!(validate_xml_against_xsd("<data>AA ZZ</data>", xsd).is_err());
 }
+
+// ─── Nullable xs:choice regression (fastkml / KML issue) ────────────────
+//
+// A `<choice>` whose alternatives are all optional (every alternative has
+// minOccurs=0) is nullable: it is satisfied by matching nothing. Such a
+// choice appearing in a sequence must not reject a following element that
+// belongs to a later particle. Regression for the KML AbstractFeatureType
+// pattern, where an optional `Snippet|snippet` choice precedes the
+// substitution-group feature list and previously caused
+// "Element 'Placemark' does not match any choice alternative".
+
+#[test]
+fn nullable_choice_in_sequence_skips_to_next_particle() {
+    let xsd = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element name="a" type="xs:string" minOccurs="0"/>
+          <xs:element name="b" type="xs:string" minOccurs="0"/>
+        </xs:choice>
+        <xs:element name="c" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    // `c` follows the all-optional choice; the choice must consume nothing.
+    assert!(validate_xml_against_xsd("<root><c>x</c></root>", xsd).is_ok());
+    // The choice can still be taken.
+    assert!(validate_xml_against_xsd("<root><a>x</a><c>y</c></root>", xsd).is_ok());
+    // Empty is valid too.
+    assert!(validate_xml_against_xsd("<root/>", xsd).is_ok());
+}
+
+#[test]
+fn required_choice_with_no_optional_alternatives_still_errors() {
+    // A choice with no optional alternative is NOT nullable: a non-matching
+    // child must still be rejected (guards against the fix over-relaxing).
+    let xsd = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="a" type="xs:string"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(validate_xml_against_xsd("<root><a>x</a></root>", xsd).is_ok());
+    assert!(validate_xml_against_xsd("<root><c>x</c></root>", xsd).is_err());
+}
+
+#[test]
+fn kml_style_optional_choice_before_substitution_group() {
+    // Faithful reduction of the KML AbstractFeatureType / DocumentType shape:
+    // an optional inline choice inside the (extended) sequence, followed by a
+    // reference to an abstract substitution-group head. A substituting member
+    // (Placemark) as the only child must validate.
+    let xsd = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:kml" xmlns:k="urn:kml" elementFormDefault="qualified">
+  <xs:element name="AbstractFeatureGroup" type="k:AbstractFeatureType" abstract="true"/>
+  <xs:complexType name="AbstractFeatureType" abstract="true">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="Snippet" type="xs:string" minOccurs="0"/>
+        <xs:element name="snippet" type="xs:string" minOccurs="0"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Placemark" type="k:PlacemarkType" substitutionGroup="k:AbstractFeatureGroup"/>
+  <xs:complexType name="PlacemarkType">
+    <xs:complexContent><xs:extension base="k:AbstractFeatureType"/></xs:complexContent>
+  </xs:complexType>
+  <xs:element name="Document" type="k:DocumentType"/>
+  <xs:complexType name="DocumentType">
+    <xs:complexContent>
+      <xs:extension base="k:AbstractFeatureType">
+        <xs:sequence>
+          <xs:element ref="k:AbstractFeatureGroup" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>"#;
+    let xml = r#"<Document xmlns="urn:kml"><Placemark/></Document>"#;
+    assert!(
+        validate_xml_against_xsd(xml, xsd).is_ok(),
+        "{:?}",
+        validate_xml_against_xsd(xml, xsd)
+    );
+}

--- a/tests/xsd_conformance.rs
+++ b/tests/xsd_conformance.rs
@@ -701,11 +701,8 @@ fn kml_style_optional_choice_before_substitution_group() {
   </xs:complexType>
 </xs:schema>"#;
     let xml = r#"<Document xmlns="urn:kml"><Placemark/></Document>"#;
-    assert!(
-        validate_xml_against_xsd(xml, xsd).is_ok(),
-        "{:?}",
-        validate_xml_against_xsd(xml, xsd)
-    );
+    let result = validate_xml_against_xsd(xml, xsd);
+    assert!(result.is_ok(), "{:?}", result);
 }
 
 #[test]
@@ -729,11 +726,8 @@ fn nullable_choice_via_optional_sequence_alternative() {
     </xs:complexType>
   </xs:element>
 </xs:schema>"#;
-    assert!(
-        validate_xml_against_xsd("<root><c>x</c></root>", xsd).is_ok(),
-        "{:?}",
-        validate_xml_against_xsd("<root><c>x</c></root>", xsd)
-    );
+    let result = validate_xml_against_xsd("<root><c>x</c></root>", xsd);
+    assert!(result.is_ok(), "{:?}", result);
     assert!(validate_xml_against_xsd("<root><a>x</a><c>y</c></root>", xsd).is_ok());
     assert!(validate_xml_against_xsd("<root/>", xsd).is_ok());
 }

--- a/tests/xsd_conformance.rs
+++ b/tests/xsd_conformance.rs
@@ -707,3 +707,33 @@ fn kml_style_optional_choice_before_substitution_group() {
         validate_xml_against_xsd(xml, xsd)
     );
 }
+
+#[test]
+fn nullable_choice_via_optional_sequence_alternative() {
+    // A choice alternative can be nullable through its *content*: a sequence
+    // whose sub-particles are all optional matches the empty sequence, so the
+    // enclosing choice is nullable even though the alternative's own minOccurs
+    // is 1. A following element must still be accepted.
+    let xsd = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element name="a" type="xs:string" minOccurs="0"/>
+            <xs:element name="b" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:choice>
+        <xs:element name="c" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        validate_xml_against_xsd("<root><c>x</c></root>", xsd).is_ok(),
+        "{:?}",
+        validate_xml_against_xsd("<root><c>x</c></root>", xsd)
+    );
+    assert!(validate_xml_against_xsd("<root><a>x</a><c>y</c></root>", xsd).is_ok());
+    assert!(validate_xml_against_xsd("<root/>", xsd).is_ok());
+}


### PR DESCRIPTION
Two changes, version bumped 0.5.1 -> 0.5.2

1. dom: add Document::declare_namespace(node, prefix, uri) -> bool

   Records an xmlns / xmlns:* binding in
   Element::namespace_declarations (upsert per prefix; None or ""
   means the default namespace), returning false for non-element
   nodes. This is the proper way to declare a namespace
   programmatically: setting an attribute literally named "xmlns" is
   sanitized to xmlns_ on output, whereas this serializes as a real
   declaration. The serializer still filters reserved bindings (the
   xmlns prefix, xml bound to a non-XML URI, any prefix bound to the
   XMLNS namespace), so declaring those is a no-op on output.

2. xsd: treat an all-optional xs:choice as nullable

   A <choice> whose alternatives are all optional (every alternative
   has minOccurs=0) is satisfiable by matching nothing.
   validate_choice no longer reports "Element '...' does not match
   any choice alternative" for a non-matching child in that case; the
   choice consumes zero children and an enclosing sequence proceeds
   to its next particle. Fixes rejection of valid KML (e.g.
   <Document><Placemark/></Document>), where an optional
   Snippet|snippet choice precedes the substitution-group feature
   list. A required choice with no optional alternative still errors.

Add regression tests: declare_namespace (prefixed, default-in-namespace, upsert, non-element) in serialization_conformance.rs; nullable-choice, required-choice-still-errors, and the KML optional-choice-before- substitution-group pattern in xsd_conformance.rs. Validated end-to-end against the real ogckml22.xsd.