### PR TITLE
add: dom and writer related features

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1309,10 +1309,14 @@ impl<'a> Document<'a> {
                     .iter()
                     .map(|(p, u)| (Cow::Owned(p.to_string()), Cow::Owned(u.to_string())))
                     .collect();
-                if let Some(NodeKind::Element(el)) = self.node_kind_mut(new_id) {
-                    el.attributes = attributes;
-                    el.namespace_declarations = ns_decls;
-                }
+                // `create_element` always allocates an element node, so this is
+                // an invariant rather than a recoverable case: a non-element here
+                // would mean a silently partially-copied subtree. Fail loudly.
+                let el = self
+                    .element_mut(new_id)
+                    .expect("create_element must allocate an element node");
+                el.attributes = attributes;
+                el.namespace_declarations = ns_decls;
                 new_id
             }
             NodeKind::Text(t) => self.create_text(Cow::Owned(t.to_string())),

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1278,8 +1278,13 @@ impl<'a> Document<'a> {
     /// responsibility (mirroring the previous behaviour). Document and virtual
     /// attribute nodes cannot be imported and yield `None`.
     pub fn import_subtree<'b>(&mut self, src: &Document<'b>, src_id: NodeId) -> Option<NodeId> {
+        // Only invalidate the XPath caches when the import actually mutates this
+        // document. A rejected root (invalid `src_id`, or a `Document`/`Attribute`
+        // node) returns `None` from `import_node_rec` before creating any node, so
+        // a no-op import must not force an unnecessary `prepare_xpath()` rebuild.
+        let new_id = self.import_node_rec(src, src_id)?;
         self.invalidate_xpath_caches();
-        self.import_node_rec(src, src_id)
+        Some(new_id)
     }
 
     /// Recursive worker for [`import_subtree`](Self::import_subtree). Creates the
@@ -1321,9 +1326,11 @@ impl<'a> Document<'a> {
             // a movable subtree.
             NodeKind::Document | NodeKind::Attribute(_, _) => return None,
         };
-        // Import children in order. `src.children` snapshots the ids up front, so
-        // mutating `self` while iterating is sound (different arenas).
-        for child in src.children(src_id) {
+        // Import children in order. `children_iter` walks `src`'s sibling links
+        // without allocating a `Vec` per recursion level; iterating `src` while
+        // mutating `self` is sound because they are distinct arenas (the iterator
+        // borrows `src`, never `self`).
+        for child in src.children_iter(src_id) {
             if let Some(child_new) = self.import_node_rec(src, child) {
                 self.append_child_unchecked(new_id, child_new);
             }

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -128,6 +128,18 @@ impl<'a> fmt::Display for QName<'a> {
     }
 }
 
+/// Clone a borrowed [`QName`] into an owned (`'static`) one. Used when importing
+/// a subtree from another document, where every string must be owned so the
+/// result does not borrow from the source. The `'static` result coerces to any
+/// `QName<'a>` via the type's covariance in its lifetime.
+fn own_qname(q: &QName<'_>) -> QName<'static> {
+    QName {
+        namespace_uri: q.namespace_uri.as_ref().map(|s| Cow::Owned(s.to_string())),
+        prefix: q.prefix.as_ref().map(|s| Cow::Owned(s.to_string())),
+        local_name: Cow::Owned(q.local_name.to_string()),
+    }
+}
+
 /// An iterator over the children of a node.
 ///
 /// This is a zero-allocation alternative to [`Document::children()`] which
@@ -1249,6 +1261,76 @@ impl<'a> Document<'a> {
         }
     }
 
+    /// Deep-copy a node and its entire subtree from another document into this
+    /// one, returning the new (detached) root node id.
+    ///
+    /// `NodeId`s are scoped to a single document's arena, so an element cannot be
+    /// reparented across documents directly; moving a subtree between documents
+    /// requires cloning it. This is the native equivalent of the per-node Python
+    /// clone the etree layer used to do for cross-tree `append`/`deepcopy`, which
+    /// dominated pyFF's aggregation step (see pyFF/performance.md): it recreates
+    /// the whole subtree in one native pass instead of one FFI call per node.
+    ///
+    /// All copied strings (names, namespace declarations, attribute values, text)
+    /// are taken by value as owned data, so the result is independent of `src`'s
+    /// lifetime. The element's own namespace declarations are copied; namespaces
+    /// inherited from ancestors *outside* the subtree are the caller's
+    /// responsibility (mirroring the previous behaviour). Document and virtual
+    /// attribute nodes cannot be imported and yield `None`.
+    pub fn import_subtree<'b>(&mut self, src: &Document<'b>, src_id: NodeId) -> Option<NodeId> {
+        self.invalidate_xpath_caches();
+        self.import_node_rec(src, src_id)
+    }
+
+    /// Recursive worker for [`import_subtree`](Self::import_subtree). Creates the
+    /// node for `src_id` in this document, then imports each child and appends it.
+    fn import_node_rec<'b>(&mut self, src: &Document<'b>, src_id: NodeId) -> Option<NodeId> {
+        let new_id = match src.node_kind(src_id)? {
+            NodeKind::Element(e) => {
+                let new_id = self.create_element(own_qname(&e.name));
+                // Copy attributes and the element's own namespace declarations.
+                // Building owned (`'static`) data that coerces into this
+                // document's lifetime `'a`.
+                let attributes: Vec<Attribute<'a>> = e
+                    .attributes
+                    .iter()
+                    .map(|a| Attribute {
+                        name: own_qname(&a.name),
+                        value: Cow::Owned(a.value.to_string()),
+                    })
+                    .collect();
+                let ns_decls: Vec<(Cow<'a, str>, Cow<'a, str>)> = e
+                    .namespace_declarations
+                    .iter()
+                    .map(|(p, u)| (Cow::Owned(p.to_string()), Cow::Owned(u.to_string())))
+                    .collect();
+                if let Some(NodeKind::Element(el)) = self.node_kind_mut(new_id) {
+                    el.attributes = attributes;
+                    el.namespace_declarations = ns_decls;
+                }
+                new_id
+            }
+            NodeKind::Text(t) => self.create_text(Cow::Owned(t.to_string())),
+            NodeKind::CData(t) => self.create_cdata(Cow::Owned(t.to_string())),
+            NodeKind::Comment(t) => self.create_comment(Cow::Owned(t.to_string())),
+            NodeKind::ProcessingInstruction(pi) => self.create_processing_instruction(
+                Cow::Owned(pi.target.to_string()),
+                pi.data.as_ref().map(|d| Cow::Owned(d.to_string())),
+            ),
+            // The document root and virtual XPath attribute nodes are not part of
+            // a movable subtree.
+            NodeKind::Document | NodeKind::Attribute(_, _) => return None,
+        };
+        // Import children in order. `src.children` snapshots the ids up front, so
+        // mutating `self` while iterating is sound (different arenas).
+        for child in src.children(src_id) {
+            if let Some(child_new) = self.import_node_rec(src, child) {
+                self.append_child_unchecked(new_id, child_new);
+            }
+        }
+        Some(new_id)
+    }
+
     fn valid_node_id(&self, id: NodeId) -> bool {
         id.0 < self.nodes.len()
     }
@@ -2112,6 +2194,48 @@ mod dom_tests {
             doc.doc_order_at(b),
             u32::MAX,
             "re-prepare did not reindex the appended node"
+        );
+    }
+
+    /// `import_subtree` deep-copies an element subtree (name, namespace
+    /// declarations, attributes, nested text/children) from one document into
+    /// another, producing an independent, attachable node.
+    #[test]
+    fn import_subtree_deep_copies_across_documents() {
+        let src = Parser::new()
+            .parse(r#"<m:Root xmlns:m="urn:m"><m:Child a="1">hi<m:Leaf/></m:Child></m:Root>"#)
+            .unwrap();
+        let src_root = src.document_element().unwrap();
+        let src_child = src.first_child(src_root).unwrap();
+
+        let mut dst = Parser::new().parse("<dst/>").unwrap();
+        let dst_root = dst.document_element().unwrap();
+
+        let imported = dst
+            .import_subtree(&src, src_child)
+            .expect("element subtree should import");
+        dst.append_child(dst_root, imported);
+
+        // The cloned subtree serializes with its name, namespace, attribute and
+        // descendants intact under the destination root.
+        let out = dst.to_xml();
+        assert!(
+            out.contains(r#"<m:Child"#)
+                && out.contains(r#"a="1""#)
+                && out.contains("hi")
+                && out.contains("<m:Leaf"),
+            "unexpected import output: {out}"
+        );
+
+        // The copy is independent: mutating the destination subtree must not be
+        // visible through the source document.
+        if let Some(NodeKind::Element(e)) = dst.node_kind_mut(imported) {
+            e.set_attribute(QName::local("a"), Cow::Borrowed("2"));
+        }
+        assert_eq!(
+            src.get_attribute(src_child, "a"),
+            Some("1"),
+            "source must be untouched by destination mutation"
         );
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -683,6 +683,81 @@ fn write_sanitized_attr_to_string(
 mod tests {
     use super::*;
 
+    // ─── Run-based escaping core (text + attribute) ────────────────────
+
+    fn esc_text(s: &str) -> String {
+        let mut buf = String::new();
+        write_escaped_text_to_string(&mut buf, s);
+        buf
+    }
+
+    fn esc_attr(s: &str) -> String {
+        let mut buf = String::new();
+        write_escaped_attr_to_string(&mut buf, s);
+        buf
+    }
+
+    #[test]
+    fn text_escaping_handles_markup_and_cr() {
+        // In text context `& < >` and CR are escaped; `" \t \n` are NOT.
+        assert_eq!(
+            esc_text("a & b < c > d\r\n\t\"x\""),
+            "a &amp; b &lt; c &gt; d&#xD;\n\t\"x\""
+        );
+        // A run with no special bytes is copied verbatim (bulk path).
+        assert_eq!(esc_text("plain ascii text 123"), "plain ascii text 123");
+        // Leading and trailing specials (run boundaries at both ends).
+        assert_eq!(esc_text("<x>"), "&lt;x&gt;");
+    }
+
+    #[test]
+    fn attr_escaping_adds_quote_tab_newline() {
+        // Attribute context additionally escapes `"`, TAB and LF; CR too.
+        assert_eq!(
+            esc_attr("a & b < c > d \"q\" \t \n \r"),
+            "a &amp; b &lt; c &gt; d &quot;q&quot; &#x9; &#xA; &#xD;"
+        );
+        // `>` is escaped in both contexts, `'` is left as-is.
+        assert_eq!(esc_attr("'apos' > gt"), "'apos' &gt; gt");
+    }
+
+    #[test]
+    fn invalid_xml_control_chars_become_replacement() {
+        // NUL and other C0 controls (except \t \n \r) are not valid XML 1.0
+        // characters and are replaced with U+FFFD in both contexts.
+        assert_eq!(esc_text("a\u{0}b"), "a\u{FFFD}b");
+        assert_eq!(
+            esc_text("\u{1}\u{8}\u{B}\u{C}\u{1F}"),
+            "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(esc_attr("x\u{0}y"), "x\u{FFFD}y");
+        // \t \n \r remain valid XML chars in text context (not replaced).
+        assert_eq!(esc_text("\t\n\r"), "\t\n&#xD;");
+    }
+
+    #[test]
+    fn multibyte_chars_pass_through_or_sanitize() {
+        // Valid multi-byte UTF-8 is copied verbatim, even adjacent to specials.
+        assert_eq!(esc_text("café & déjà-vu — ☃"), "café &amp; déjà-vu — ☃");
+        assert_eq!(esc_attr("naïve=\"x\""), "naïve=&quot;x&quot;");
+        // U+FFFE is a non-character (invalid XML char) and is replaced, while
+        // the surrounding valid multi-byte characters survive.
+        assert_eq!(esc_text("é\u{FFFE}é"), "é\u{FFFD}é");
+        assert_eq!(esc_attr("é\u{FFFE}é"), "é\u{FFFD}é");
+    }
+
+    #[test]
+    fn escaping_matches_public_writer_api() {
+        // The public `text` / attribute paths route through the same core.
+        let mut w = XmlWriter::new();
+        w.text("a & b < c\r");
+        assert_eq!(w.as_str(), "a &amp; b &lt; c&#xD;");
+
+        let mut w = XmlWriter::new();
+        w.empty_element("e", &[("k", "v & \"w\"\t")]);
+        assert_eq!(w.into_string(), "<e k=\"v &amp; &quot;w&quot;&#x9;\"/>");
+    }
+
     // ─── Pure-function tests for the sanitizers ────────────────────────
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -575,33 +575,92 @@ fn is_ncname_char(c: char) -> bool {
 
 // ─── Internal escaping helpers (write directly to String, no allocation) ───
 
+/// Run-based XML escaping core, shared by the text and attribute writers.
+///
+/// Instead of matching and pushing one character at a time (the bulk of a large
+/// document is unescaped text, so that pays a per-character `push` capacity
+/// check and UTF-8 re-encode over and over), this scans for the next byte that
+/// actually needs escaping or sanitizing and copies the whole preceding "safe"
+/// run in one `push_str` (which lowers to a SIMD `memcpy`). On ASCII-heavy
+/// payloads like SAML metadata this is the common case, so most bytes are
+/// copied in bulk and only the rare special byte is handled individually.
+///
+/// Semantics are identical to the previous per-character version: `&<>` and
+/// `\r` are always escaped; in attribute context `"`, `\t` and `\n` are escaped
+/// too; control characters that are not valid XML 1.0 characters are replaced
+/// with U+FFFD (via the same rule as [`sanitized_xml_char`]); everything else,
+/// including valid multi-byte characters, is copied verbatim.
+#[inline]
+fn write_escaped_run_based(buf: &mut String, s: &str, is_attr: bool) {
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Decide whether byte `b` needs individual handling. ASCII bytes take a
+        // cheap branch; any byte >= 0x80 starts a multi-byte char and is decoded
+        // on the slow path (rare in this workload).
+        let special = if b >= 0x80 {
+            true
+        } else {
+            match b {
+                b'&' | b'<' | b'>' | b'\r' => true,
+                b'"' if is_attr => true,
+                b'\t' | b'\n' if is_attr => true,
+                // Control characters other than XML-valid \t, \n (and \r, which
+                // is handled above) must be sanitized.
+                0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F => true,
+                _ => false,
+            }
+        };
+        if !special {
+            i += 1;
+            continue;
+        }
+        // Flush the accumulated safe run in one bulk copy.
+        if start < i {
+            buf.push_str(&s[start..i]);
+        }
+        if b >= 0x80 {
+            // Multi-byte UTF-8 character: copy it verbatim when it is a valid
+            // XML character, otherwise emit the replacement character.
+            let ch = s[i..].chars().next().unwrap();
+            let n = ch.len_utf8();
+            if is_xml_char(ch) {
+                buf.push_str(&s[i..i + n]);
+            } else {
+                buf.push('\u{FFFD}');
+            }
+            i += n;
+        } else {
+            match b {
+                b'&' => buf.push_str("&amp;"),
+                b'<' => buf.push_str("&lt;"),
+                b'>' => buf.push_str("&gt;"),
+                b'\r' => buf.push_str("&#xD;"),
+                b'"' if is_attr => buf.push_str("&quot;"),
+                b'\t' if is_attr => buf.push_str("&#x9;"),
+                b'\n' if is_attr => buf.push_str("&#xA;"),
+                // Remaining ASCII control characters are all invalid XML chars.
+                _ => buf.push(sanitized_xml_char(b as char)),
+            }
+            i += 1;
+        }
+        start = i;
+    }
+    if start < bytes.len() {
+        buf.push_str(&s[start..]);
+    }
+}
+
 /// Write text content with XML escaping directly to a String.
 fn write_escaped_text_to_string(buf: &mut String, s: &str) {
-    for c in s.chars() {
-        match c {
-            '&' => buf.push_str("&amp;"),
-            '<' => buf.push_str("&lt;"),
-            '>' => buf.push_str("&gt;"),
-            '\r' => buf.push_str("&#xD;"),
-            _ => buf.push(sanitized_xml_char(c)),
-        }
-    }
+    write_escaped_run_based(buf, s, false);
 }
 
 /// Write attribute value with XML escaping directly to a String.
 fn write_escaped_attr_to_string(buf: &mut String, s: &str) {
-    for c in s.chars() {
-        match c {
-            '&' => buf.push_str("&amp;"),
-            '<' => buf.push_str("&lt;"),
-            '>' => buf.push_str("&gt;"),
-            '"' => buf.push_str("&quot;"),
-            '\t' => buf.push_str("&#x9;"),
-            '\n' => buf.push_str("&#xA;"),
-            '\r' => buf.push_str("&#xD;"),
-            _ => buf.push(sanitized_xml_char(c)),
-        }
-    }
+    write_escaped_run_based(buf, s, true);
 }
 
 /// Write one attribute after structural-name sanitization and per-element


### PR DESCRIPTION
Two independent changes used by the pyuppsala DOM wrapper to speed up its lxml.etree-compatible layer (cross-tree element moves and serialization).

dom: Document::import_subtree

- Add Document::import_subtree(&mut self, src, src_id) -> Option<NodeId>: deep-copy a node and its entire subtree from another document into this one in a single native pass, returning the new detached root node id.
- NodeIds are scoped to one document's arena, so an element cannot be reparented across documents directly; moving a subtree between documents requires cloning it. This recreates the element (qualified name, the element's own namespace declarations, attributes), text/CDATA/comment/PI nodes, and all descendants, taking every copied string by value as owned data so the result is independent of the source document's lifetime.
- The document root and virtual XPath attribute nodes are not part of a movable subtree and yield None. Namespaces inherited from ancestors outside the subtree are the caller's responsibility, matching the previous behaviour.
- Adds an own_qname helper and a unit test that imports a namespaced subtree with an attribute and nested children across documents and asserts the copy is independent of the source.

writer: run-based XML escaping

- Replace the per-character text/attribute escaping (a match plus a push per char) with a shared run-based core: scan for the next byte that actually needs escaping or sanitization and bulk-copy the preceding safe run with one push_str (which lowers to a SIMD memcpy). On ASCII-heavy payloads like SAML metadata most bytes are copied in bulk and only the rare special byte is handled individually.
- Output is byte-identical to the previous version: & < > and CR are always escaped; in attribute context " TAB and LF are escaped too; control characters that are not valid XML 1.0 characters become U+FFFD; everything else, including valid multi-byte characters, is copied verbatim. All serialization and writer tests pass unchanged.