### PR TITLE
fix(xsd): resolve schemaLocation base_path directory

### DIFF
--- a/src/xsd/composition.rs
+++ b/src/xsd/composition.rs
@@ -219,7 +219,27 @@ pub(super) fn process_schema_composition(
         )));
     }
 
-    let base_dir = base_path.and_then(|p| p.parent());
+    // `base_path` is either the schema *directory* or the schema *file*:
+    //   * the public entry (`from_file`, and the etree `XMLSchema(file=...)`
+    //     facade, which passes `os.path.dirname(file)`) supplies a directory,
+    //     since the top-level schema is handed in as a string with no file of
+    //     its own;
+    //   * recursive `xs:import`/`xs:include`/`xs:redefine` loads pass the
+    //     resolved schema *file* path (see the `from_schema_with_composition_state`
+    //     calls below).
+    // `schemaLocation` is resolved relative to the directory in both cases, so
+    // use `base_path` directly when it is a directory and its parent otherwise.
+    // The previous unconditional `.parent()` treated a directory as a file and
+    // stripped one level, so every import/include from the public entry silently
+    // failed to resolve and all imported declarations (types *and* elements) went
+    // missing -- surfacing as "No element declaration found" / "Type not found".
+    let base_dir = base_path.map(|p| {
+        if p.is_dir() {
+            p
+        } else {
+            p.parent().unwrap_or(p)
+        }
+    });
     // Canonicalize the base once per call; reused as the containment
     // anchor for every schemaLocation resolved in the loop below.
     //

--- a/src/xsd/composition.rs
+++ b/src/xsd/composition.rs
@@ -227,17 +227,32 @@ pub(super) fn process_schema_composition(
     //   * recursive `xs:import`/`xs:include`/`xs:redefine` loads pass the
     //     resolved schema *file* path (see the `from_schema_with_composition_state`
     //     calls below).
-    // `schemaLocation` is resolved relative to the directory in both cases, so
-    // use `base_path` directly when it is a directory and its parent otherwise.
-    // The previous unconditional `.parent()` treated a directory as a file and
-    // stripped one level, so every import/include from the public entry silently
-    // failed to resolve and all imported declarations (types *and* elements) went
-    // missing -- surfacing as "No element declaration found" / "Type not found".
-    let base_dir = base_path.map(|p| {
-        if p.is_dir() {
-            p
+    // `schemaLocation` is resolved relative to the directory in both cases.
+    //
+    // Only a path that is *known to be a regular file* (the recursive loads) is
+    // reduced to its parent directory. A directory, or any path that cannot be
+    // stat'd (missing or unreadable), is kept as the base directory itself. This
+    // matters for the fail-closed contract below: a bad base directory must
+    // still fail to canonicalize and be rejected, rather than silently resolving
+    // against its parent -- which a `!is_dir()` test would do, since `is_dir()`
+    // also returns false for a missing/unreadable directory.
+    //
+    // (The previous unconditional `.parent()` treated the public entry's
+    // directory as a file and stripped one level, so every import/include
+    // silently failed to resolve and all imported declarations -- types *and*
+    // elements -- went missing, surfacing as "No element declaration found" /
+    // "Type not found".)
+    let base_dir: Option<PathBuf> = base_path.map(|p| {
+        if p.is_file() {
+            // A file always has a parent; an empty parent denotes the current
+            // directory, so fall back to "." rather than the file path itself
+            // (joining onto the file would yield e.g. `schema.xsd/inner.xsd`).
+            match p.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+                _ => PathBuf::from("."),
+            }
         } else {
-            p.parent().unwrap_or(p)
+            p.to_path_buf()
         }
     });
     // Canonicalize the base once per call; reused as the containment
@@ -248,7 +263,7 @@ pub(super) fn process_schema_composition(
     // etc.). Falling through to `canonical_base = None` would skip the
     // containment check inside `resolve_include_path` and re-open the
     // arbitrary-file-read window F-10 closed.
-    let canonical_base = match base_dir {
+    let canonical_base = match &base_dir {
         Some(b) => Some(b.canonicalize().map_err(|e| {
             XmlError::validation(format!(
                 "Failed to canonicalize schema base directory '{}': {}",
@@ -284,7 +299,7 @@ pub(super) fn process_schema_composition(
                     let kind = if is_redefine { "redefine" } else { "include" };
                     let resolved_schema = match resolve_include_path(
                         schema_location,
-                        base_dir,
+                        base_dir.as_deref(),
                         canonical_base.as_deref(),
                         state,
                         kind,
@@ -368,7 +383,7 @@ pub(super) fn process_schema_composition(
                     // not silently dropped.
                     let resolved_schema = match resolve_include_path(
                         schema_location,
-                        base_dir,
+                        base_dir.as_deref(),
                         canonical_base.as_deref(),
                         state,
                         "import",

--- a/tests/xsd_composition.rs
+++ b/tests/xsd_composition.rs
@@ -202,6 +202,36 @@ fn import_resolves_with_directory_base_path() {
     );
 }
 
+/// Regression: a `base_path` directory that does not exist must fail closed,
+/// not silently resolve `schemaLocation` against its (existing) parent.
+///
+/// The effective base directory is computed by reducing only a *known regular
+/// file* to its parent; a missing/unreadable path is kept as the directory so
+/// the canonicalize-or-reject guard fires. A `!is_dir()` test would instead
+/// treat the missing directory as a file and fall back to its parent, which may
+/// canonicalize successfully and re-open the contained-resolution hole.
+#[test]
+fn missing_base_directory_fails_closed() {
+    let parent = mkdir_unique("missing-base-parent");
+    let missing = parent.join("does-not-exist");
+
+    let schema = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:agg" version="1.0">
+  <xs:import namespace="urn:test:inner" schemaLocation="inner.xsd"/>
+</xs:schema>"#;
+
+    let schema_doc = parse(schema).expect("parse schema");
+    let built = XsdValidator::from_schema_with_base_path(&schema_doc, Some(missing.as_path()));
+    fs::remove_dir_all(&parent).ok();
+
+    assert!(
+        built.is_err(),
+        "a missing base directory must fail closed (canonicalize error), not \
+         resolve imports against its parent",
+    );
+}
+
 /// Regression: `<xs:attribute ref="foreign:attr"/>` across an `xs:import`
 /// boundary. Before the fix, the prefix was stripped and the lookup keyed
 /// against the outer schema's targetNamespace, so the imported global

--- a/tests/xsd_composition.rs
+++ b/tests/xsd_composition.rs
@@ -138,6 +138,70 @@ Text with <i:ref term="x"/> and <o:b>bold</o:b> and <i:ref term="y"/>.
     );
 }
 
+/// Regression: `xs:import` must resolve `schemaLocation` when the caller passes
+/// the schema *directory* as `base_path`, not just the schema *file*.
+///
+/// The public entry points hand a directory to `from_schema_with_base_path`:
+/// the schema is supplied as a string (no file of its own), and the pyuppsala
+/// `XsdValidator.from_file(schema_xml, base_path)` / etree
+/// `XMLSchema(file=...)` facade passes `os.path.dirname(file)`. Composition
+/// used to do `base_path.parent()` unconditionally, treating that directory as
+/// a file and stripping one level, so every `xs:import`/`xs:include` silently
+/// failed to resolve and *all* imported declarations (types **and** the global
+/// element used to validate the instance root) went missing -- surfacing as
+/// "No element declaration found for '<root>'". This test passes the directory
+/// (as the real callers do) and asserts the imported global element resolves.
+///
+/// The sibling tests above pass the schema *file* path, whose `.parent()` is
+/// the directory, so they validated correctly even with the bug and never
+/// exercised this path.
+#[test]
+fn import_resolves_with_directory_base_path() {
+    let dir = mkdir_unique("import-dir-base");
+
+    // Imported schema declares a global element (and its type) in its own
+    // namespace -- this is the element used to validate the instance root.
+    let inner = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:i="urn:test:inner"
+           targetNamespace="urn:test:inner"
+           elementFormDefault="qualified">
+  <xs:element name="Thing" type="i:ThingType"/>
+  <xs:complexType name="ThingType">
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>"#;
+    fs::write(dir.join("inner.xsd"), inner).unwrap();
+
+    // Entry schema (different targetNamespace) only imports the inner one.
+    let composite = r#"<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:aggregate" version="1.0">
+  <xs:import namespace="urn:test:inner" schemaLocation="inner.xsd"/>
+</xs:schema>"#;
+
+    let instance = r#"<i:Thing xmlns:i="urn:test:inner" id="x"/>"#;
+
+    // Pass the DIRECTORY as base_path (what the public callers do), NOT the
+    // schema file path.
+    let schema_doc = parse(composite).expect("parse composite schema");
+    let validator = XsdValidator::from_schema_with_base_path(&schema_doc, Some(dir.as_path()))
+        .expect("build validator from directory base_path");
+    let doc = parse(instance).expect("parse instance");
+    let errors: Vec<String> = validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| format!("{e}"))
+        .collect();
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(
+        errors.is_empty(),
+        "imported global element must resolve when base_path is the schema \
+         directory, got: {errors:?}",
+    );
+}
+
 /// Regression: `<xs:attribute ref="foreign:attr"/>` across an `xs:import`
 /// boundary. Before the fix, the prefix was stripped and the lookup keyed
 /// against the outer schema's targetNamespace, so the imported global


### PR DESCRIPTION
xs:import and xs:include silently failed to resolve whenever the caller passed the schema directory (not a schema file) as base_path, so every imported declaration (types and the global element used to validate the instance root) went missing. This surfaced as spurious "No element declaration found for '<root>'" and "Type '<qname>' not found".

Root cause: process_schema_composition computed the resolution directory as base_path.parent() unconditionally, treating base_path as a file. But the public entry points hand it a directory: the top-level schema is supplied as a string with no file of its own, and the pyuppsala XsdValidator.from_file / pyuppsala.etree XMLSchema(file=...) facade passes os.path.dirname(file). Taking .parent() of a directory resolved sibling schemas against the wrong parent, so the schemaLocation hint never matched a real file and the import was skipped.

Fix: use base_path directly when it is a directory and its parent otherwise, so both the public directory entry and the recursive file-path loads (nested xs:import / xs:include) resolve correctly.

The existing composition tests all passed a schema file path, whose parent is the directory, so they validated correctly even with the bug and never exercised this path. Add
import_resolves_with_directory_base_path, which passes the directory as the real callers do and asserts an imported global element resolves as the instance root; it fails against the old base_path.parent() and passes with the fix.

Fixes #22 