### PR TITLE
security: harden XML validation and transform boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-07-02
+
+### Security
+
+- XSD validation now fails closed for unresolved element references instead of
+  validating them as unconstrained content, and namespace-sensitive attribute
+  declarations and strict attribute wildcards now compare expanded names instead
+  of falling back to local-name matches.
+- XSD datatype and facet validation is stricter for hostile inputs: date/time
+  facets compare actual instants, non-temporal enumerations no longer receive
+  date/time normalization, malformed negative dates are rejected, invalid pattern
+  facets fail closed, and `xs:QName` rejects unbound prefixes.
+- XSD identity constraints now reject `xs:unique`, `xs:key`, and `xs:keyref`
+  fields that select more than one node, preserving the XSD single-field-value
+  rule instead of silently choosing the first value.
+- DTD content-model parsing now observes the parser nesting-depth limit, so
+  deeply nested declarations fail gracefully with the same configurable cap as
+  element nesting.
+- XSLT generated comments and processing instructions reject content that would
+  break out of XML markup, and opt-in EXSLT `str:padding()` is capped to prevent
+  attacker-selected output allocation.
+
 ## [0.7.0] - 2026-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uppsala"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "A pure Rust XML parser, DOM, namespace, XPath, and XSD validation library"
 license = "BSD-2-Clause"

--- a/docs/adr/0013-security-hardening-0.7.1.md
+++ b/docs/adr/0013-security-hardening-0.7.1.md
@@ -1,0 +1,65 @@
+# ADR 0013: Fail-closed XML stack hardening for 0.7.1
+
+## Status
+
+Accepted
+
+## Context
+
+The 0.7.0 release added the first public XSLT engine and opt-in EXSLT support on
+top of the existing parser, DOM, XPath, and XSD validator. A follow-up security
+scan of the repository and its downstream `bergshamra` / `gamlastan` usage
+identified several places where malformed or adversarial XML could be accepted
+more permissively than intended:
+
+- XSD element and attribute references could lose namespace precision or, for
+  missing element declarations, fall back to unconstrained validation.
+- Some XSD facets were interpreted with unsafe string shortcuts: temporal values
+  were compared lexically, invalid pattern facets were skipped, string
+  enumerations could be date/time-normalized, and unbound `xs:QName` prefixes
+  were accepted.
+- Identity-constraint fields that selected multiple nodes were reduced to one
+  value instead of failing the constraint.
+- DTD content-model nesting used parser recursion without sharing the parser's
+  public depth cap.
+- XSLT constructors and opt-in EXSLT functions could turn data into markup or
+  allocate caller-selected output.
+
+These behaviours are dangerous because downstream callers often treat successful
+schema validation or transformation as a trust boundary. Accepting unexpected
+structure at this layer can make policy checks in downstream applications reason
+about a different document than the one an attacker supplied.
+
+## Decision
+
+Adopt a fail-closed hardening rule for XML security boundaries:
+
+- Missing schema declarations are validation errors, not `anyType` fallbacks.
+- Attribute declarations, attribute wildcards, identity constraints, and QName
+  values compare expanded names, including namespace URIs.
+- Invalid schema facets are validation errors.
+- Date/time facets are compared as normalized temporal values when the base type
+  is temporal, and non-temporal enumerations keep ordinary lexical comparison.
+  Temporal comparisons fail closed when either operand (including a raw facet
+  bound such as `minInclusive`/`maxInclusive`) is out of range.
+- Parser-controlled recursion limits also apply to DTD content models.
+- XSLT-generated comments and processing instructions reject data that cannot be
+  represented safely as those node kinds.
+- Opt-in EXSLT string padding has a fixed output cap.
+
+This keeps the library strict by default. The existing `XsdValidator::set_lenient`
+mode from ADR 0012 remains narrowly scoped to libxml2-compatible `xs:anyURI`
+space handling and does not weaken these security checks.
+
+## Consequences
+
+- Some documents that were previously accepted because of unresolved imports,
+  malformed schema facets, unbound QName prefixes, or ambiguous identity fields
+  now produce validation errors.
+- XSLT stylesheets that attempt to construct invalid comments or processing
+  instructions now return `XmlError` instead of serializing unsafe XML.
+- Extremely large EXSLT `str:padding()` calls now return an XPath error once the
+  requested length exceeds the cap.
+- Regression coverage for these behaviours lives in
+  `tests/security_regressions.rs` and exercises the public parser, XSD, XSLT,
+  and EXSLT APIs.

--- a/src/exslt.rs
+++ b/src/exslt.rs
@@ -24,6 +24,8 @@ use crate::dom::{Document, NodeId};
 use crate::error::XmlResult;
 use crate::xpath::{string_value_of_node, XPathValue};
 
+pub(crate) const MAX_EXSLT_PADDING_LENGTH: usize = 1_000_000;
+
 /// Resolve an EXSLT `prefix:local(args)` call. Returns `None` to fall through to
 /// the engine's "unknown function" handling. `date:date-time()` resolves
 /// regardless of `enabled`; everything else requires `enabled == true`.
@@ -209,6 +211,12 @@ fn str_fn(doc: &Document<'_>, name: &str, args: &[XPathValue]) -> Option<XmlResu
             } else {
                 0
             };
+            if len > MAX_EXSLT_PADDING_LENGTH {
+                return Some(Err(crate::error::XmlError::xpath(format!(
+                    "EXSLT str:padding length {} exceeds maximum {}",
+                    len, MAX_EXSLT_PADDING_LENGTH
+                ))));
+            }
             let pad = args
                 .get(1)
                 .map(|v| v.to_string_value(doc))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1792,7 +1792,7 @@ fn parse_content_model(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
     }
 
     // children content model
-    parse_cp(cursor, 1, max_depth)?;
+    parse_cp(cursor, 0, max_depth)?;
     cursor.skip_whitespace();
 
     if cursor.peek() == Some(')') {
@@ -1840,7 +1840,7 @@ fn parse_content_model(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
             ));
         }
         cursor.skip_whitespace();
-        parse_cp(cursor, 1, max_depth)?;
+        parse_cp(cursor, 0, max_depth)?;
     }
 }
 
@@ -1861,7 +1861,9 @@ fn parse_cp(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
 
 /// Parse a children group.
 fn parse_children_group(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
-    if depth > max_depth {
+    // Matches parse_element's guard (root depth 0, error at depth >= max_depth)
+    // so Parser::with_max_depth maps consistently across element and DTD nesting.
+    if depth >= max_depth {
         return Err(XmlError::parse(
             format!(
                 "DTD content model depth limit exceeded (max_depth={})",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,6 +190,7 @@ impl Parser {
             &mut entity_budget,
             self.forbid_dtd,
             self.forbid_entities,
+            self.max_depth,
         )?;
 
         // Parse document element and trailing misc
@@ -1359,6 +1360,7 @@ fn parse_pi<'a>(cursor: &mut Cursor<'a>) -> XmlResult<ProcessingInstruction<'a>>
 /// DOCTYPE / internal-subset parsing so any entity expansion that occurs while
 /// processing ATTLIST default values charges against the same cap as document
 /// content.
+#[allow(clippy::too_many_arguments)]
 fn parse_misc<'a>(
     cursor: &mut Cursor<'a>,
     doc: &mut Document<'a>,
@@ -1367,6 +1369,7 @@ fn parse_misc<'a>(
     entity_budget: &mut usize,
     forbid_dtd: bool,
     forbid_entities: bool,
+    max_depth: u32,
 ) -> XmlResult<()> {
     loop {
         cursor.skip_whitespace();
@@ -1393,7 +1396,14 @@ fn parse_misc<'a>(
                     cursor.column(),
                 ));
             }
-            parse_doctype(cursor, doc, entities, entity_budget, forbid_entities)?;
+            parse_doctype(
+                cursor,
+                doc,
+                entities,
+                entity_budget,
+                forbid_entities,
+                max_depth,
+            )?;
         } else {
             break;
         }
@@ -1412,6 +1422,7 @@ fn parse_doctype<'a>(
     entities: &mut EntityMap,
     entity_budget: &mut usize,
     forbid_entities: bool,
+    max_depth: u32,
 ) -> XmlResult<()> {
     let start_pos = cursor.pos;
     cursor.expect("<!DOCTYPE")?;
@@ -1469,7 +1480,7 @@ fn parse_doctype<'a>(
     // Optional internal subset
     if cursor.peek() == Some('[') {
         cursor.advance_char();
-        parse_internal_subset(cursor, entities, entity_budget, forbid_entities)?;
+        parse_internal_subset(cursor, entities, entity_budget, forbid_entities, max_depth)?;
         cursor.expect("]")?;
         cursor.skip_whitespace();
     }
@@ -1567,6 +1578,7 @@ fn parse_internal_subset(
     entities: &mut EntityMap,
     entity_budget: &mut usize,
     forbid_entities: bool,
+    max_depth: u32,
 ) -> XmlResult<()> {
     loop {
         cursor.skip_whitespace();
@@ -1582,7 +1594,7 @@ fn parse_internal_subset(
         } else if cursor.starts_with("<?") {
             parse_pi_in_dtd(cursor)?;
         } else if cursor.starts_with("<!ELEMENT") {
-            parse_element_decl(cursor)?;
+            parse_element_decl(cursor, max_depth)?;
         } else if cursor.starts_with("<!ATTLIST") {
             parse_attlist_decl(cursor, entities, entity_budget)?;
         } else if cursor.starts_with("<!ENTITY") {
@@ -1665,7 +1677,7 @@ fn reject_pe_in_markup_decl(cursor: &Cursor) -> XmlResult<()> {
 }
 
 /// Parse an ELEMENT declaration (`<!ELEMENT name contentspec>`).
-fn parse_element_decl(cursor: &mut Cursor) -> XmlResult<()> {
+fn parse_element_decl(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
     cursor.expect("<!ELEMENT")?;
 
     // Must have whitespace after <!ELEMENT
@@ -1692,7 +1704,7 @@ fn parse_element_decl(cursor: &mut Cursor) -> XmlResult<()> {
     cursor.skip_whitespace();
 
     // Parse content spec: EMPTY | ANY | Mixed | children
-    parse_content_spec(cursor)?;
+    parse_content_spec(cursor, max_depth)?;
 
     cursor.skip_whitespace();
     cursor.expect(">")?;
@@ -1700,7 +1712,7 @@ fn parse_element_decl(cursor: &mut Cursor) -> XmlResult<()> {
 }
 
 /// Parse a content specification for an ELEMENT declaration.
-fn parse_content_spec(cursor: &mut Cursor) -> XmlResult<()> {
+fn parse_content_spec(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
     if cursor.starts_with("EMPTY") {
         cursor.advance(5);
         Ok(())
@@ -1708,7 +1720,7 @@ fn parse_content_spec(cursor: &mut Cursor) -> XmlResult<()> {
         cursor.advance(3);
         Ok(())
     } else if cursor.peek() == Some('(') {
-        parse_content_model(cursor)
+        parse_content_model(cursor, max_depth)
     } else if cursor.starts_with("%") {
         reject_pe_in_markup_decl(cursor)?;
         Ok(())
@@ -1722,7 +1734,7 @@ fn parse_content_spec(cursor: &mut Cursor) -> XmlResult<()> {
 }
 
 /// Parse a content model (children or Mixed content).
-fn parse_content_model(cursor: &mut Cursor) -> XmlResult<()> {
+fn parse_content_model(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
     cursor.expect("(")?;
     cursor.skip_whitespace();
 
@@ -1780,7 +1792,7 @@ fn parse_content_model(cursor: &mut Cursor) -> XmlResult<()> {
     }
 
     // children content model
-    parse_cp(cursor)?;
+    parse_cp(cursor, 1, max_depth)?;
     cursor.skip_whitespace();
 
     if cursor.peek() == Some(')') {
@@ -1828,14 +1840,14 @@ fn parse_content_model(cursor: &mut Cursor) -> XmlResult<()> {
             ));
         }
         cursor.skip_whitespace();
-        parse_cp(cursor)?;
+        parse_cp(cursor, 1, max_depth)?;
     }
 }
 
 /// Parse a content particle.
-fn parse_cp(cursor: &mut Cursor) -> XmlResult<()> {
+fn parse_cp(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
     if cursor.peek() == Some('(') {
-        parse_children_group(cursor)?;
+        parse_children_group(cursor, depth + 1, max_depth)?;
     } else if cursor.starts_with("%") {
         reject_pe_in_markup_decl(cursor)?;
     } else {
@@ -1848,7 +1860,17 @@ fn parse_cp(cursor: &mut Cursor) -> XmlResult<()> {
 }
 
 /// Parse a children group.
-fn parse_children_group(cursor: &mut Cursor) -> XmlResult<()> {
+fn parse_children_group(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
+    if depth > max_depth {
+        return Err(XmlError::parse(
+            format!(
+                "DTD content model depth limit exceeded (max_depth={})",
+                max_depth
+            ),
+            cursor.line(),
+            cursor.column(),
+        ));
+    }
     cursor.expect("(")?;
     cursor.skip_whitespace();
 
@@ -1860,7 +1882,7 @@ fn parse_children_group(cursor: &mut Cursor) -> XmlResult<()> {
         ));
     }
 
-    parse_cp(cursor)?;
+    parse_cp(cursor, depth, max_depth)?;
     cursor.skip_whitespace();
 
     if cursor.peek() == Some(')') {
@@ -1908,7 +1930,7 @@ fn parse_children_group(cursor: &mut Cursor) -> XmlResult<()> {
             ));
         }
         cursor.skip_whitespace();
-        parse_cp(cursor)?;
+        parse_cp(cursor, depth, max_depth)?;
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1791,8 +1791,9 @@ fn parse_content_model(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
         }
     }
 
-    // children content model
-    parse_cp(cursor, 0, max_depth)?;
+    // children content model; the outer group consumed above is level 0, so
+    // any group opened by a particle inside it is at level 1
+    parse_cp(cursor, 1, max_depth)?;
     cursor.skip_whitespace();
 
     if cursor.peek() == Some(')') {
@@ -1840,14 +1841,17 @@ fn parse_content_model(cursor: &mut Cursor, max_depth: u32) -> XmlResult<()> {
             ));
         }
         cursor.skip_whitespace();
-        parse_cp(cursor, 0, max_depth)?;
+        parse_cp(cursor, 1, max_depth)?;
     }
 }
 
 /// Parse a content particle.
+///
+/// `depth` is the nesting level that a parenthesized group opened by this
+/// particle would occupy (the outermost content-model group is level 0).
 fn parse_cp(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
     if cursor.peek() == Some('(') {
-        parse_children_group(cursor, depth + 1, max_depth)?;
+        parse_children_group(cursor, depth, max_depth)?;
     } else if cursor.starts_with("%") {
         reject_pe_in_markup_decl(cursor)?;
     } else {
@@ -1859,10 +1863,12 @@ fn parse_cp(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
     Ok(())
 }
 
-/// Parse a children group.
+/// Parse a children group at nesting level `depth`.
 fn parse_children_group(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlResult<()> {
-    // Matches parse_element's guard (root depth 0, error at depth >= max_depth)
-    // so Parser::with_max_depth maps consistently across element and DTD nesting.
+    // The outermost group (level 0, consumed by parse_content_model) is the
+    // analogue of the document element at depth 0; this guard matches
+    // parse_element's (error at depth >= max_depth) so Parser::with_max_depth
+    // maps consistently across element and DTD content-model nesting.
     if depth >= max_depth {
         return Err(XmlError::parse(
             format!(
@@ -1884,7 +1890,7 @@ fn parse_children_group(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlR
         ));
     }
 
-    parse_cp(cursor, depth, max_depth)?;
+    parse_cp(cursor, depth + 1, max_depth)?;
     cursor.skip_whitespace();
 
     if cursor.peek() == Some(')') {
@@ -1932,7 +1938,7 @@ fn parse_children_group(cursor: &mut Cursor, depth: u32, max_depth: u32) -> XmlR
             ));
         }
         cursor.skip_whitespace();
-        parse_cp(cursor, depth, max_depth)?;
+        parse_cp(cursor, depth + 1, max_depth)?;
     }
 }
 

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -284,6 +284,7 @@ impl XsdValidator {
                                 default,
                                 prohibited: false,
                                 is_ref: false,
+                                qualified: true,
                             };
                             let key = (validator.target_namespace.clone(), name.to_string());
                             validator.global_attributes.insert(key, decl);
@@ -436,6 +437,7 @@ impl XsdValidator {
                                     default,
                                     prohibited: false,
                                     is_ref: false,
+                                    qualified: true,
                                 };
                                 let key = (validator.target_namespace.clone(), name.to_string());
                                 validator.global_attributes.insert(key, decl);

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -283,6 +283,7 @@ impl XsdValidator {
                                 required,
                                 default,
                                 prohibited: false,
+                                is_ref: false,
                             };
                             let key = (validator.target_namespace.clone(), name.to_string());
                             validator.global_attributes.insert(key, decl);
@@ -434,6 +435,7 @@ impl XsdValidator {
                                     required,
                                     default,
                                     prohibited: false,
+                                    is_ref: false,
                                 };
                                 let key = (validator.target_namespace.clone(), name.to_string());
                                 validator.global_attributes.insert(key, decl);

--- a/src/xsd/builder.rs
+++ b/src/xsd/builder.rs
@@ -278,6 +278,7 @@ impl XsdValidator {
                             let default = attr_elem.get_attribute("default").map(|s| s.to_string());
                             let decl = AttributeDecl {
                                 name: name.to_string(),
+                                namespace: validator.target_namespace.clone(),
                                 type_ref,
                                 required,
                                 default,
@@ -428,6 +429,7 @@ impl XsdValidator {
                                     attr_elem.get_attribute("default").map(|s| s.to_string());
                                 let decl = AttributeDecl {
                                     name: name.to_string(),
+                                    namespace: validator.target_namespace.clone(),
                                     type_ref,
                                     required,
                                     default,

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -47,6 +47,180 @@ fn is_valid_xml_name(s: &str) -> bool {
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
 }
 
+fn is_date_time_type(base_type: &BuiltInType) -> bool {
+    matches!(base_type, BuiltInType::DateTime | BuiltInType::Time)
+}
+
+fn compare_facet_values(
+    value: &str,
+    facet_value: &str,
+    base_type: &BuiltInType,
+) -> Option<Ordering> {
+    match base_type {
+        BuiltInType::DateTime => compare_datetime_values(value, facet_value),
+        BuiltInType::Time => compare_time_values(value, facet_value),
+        BuiltInType::Date
+        | BuiltInType::GYear
+        | BuiltInType::GYearMonth
+        | BuiltInType::GMonth
+        | BuiltInType::GMonthDay
+        | BuiltInType::GDay => Some(value.cmp(facet_value)),
+        _ => Some(compare_values(value, facet_value)),
+    }
+}
+
+fn compare_datetime_values(value: &str, facet_value: &str) -> Option<Ordering> {
+    // Fail closed on lexically-parseable but out-of-range values (e.g. year 0000,
+    // month 99, hour 99). Facet values are stored as raw strings and are not
+    // otherwise range-checked, so an invalid minInclusive/maxInclusive must not
+    // yield a comparable ordering.
+    if !is_valid_datetime(value) || !is_valid_datetime(facet_value) {
+        return None;
+    }
+    let left = datetime_to_utc_tuple(value)?;
+    let right = datetime_to_utc_tuple(facet_value)?;
+    Some(compare_utc_tuple(&left, &right))
+}
+
+fn compare_time_values(value: &str, facet_value: &str) -> Option<Ordering> {
+    // Fail closed on out-of-range time strings (e.g. 99:99:99Z); see
+    // compare_datetime_values for the rationale.
+    if !is_valid_time(value) || !is_valid_time(facet_value) {
+        return None;
+    }
+    let left = time_to_utc_tuple(value)?;
+    let right = time_to_utc_tuple(facet_value)?;
+    Some(compare_utc_tuple(&left, &right))
+}
+
+fn datetime_to_utc_tuple(value: &str) -> Option<(i128, String)> {
+    let (date, time) = value.split_once('T')?;
+    let (year, month, day) = parse_xsd_date_parts(date)?;
+    let (hour, minute, second, fraction, offset_minutes) = parse_xsd_time_parts(time)?;
+    let days = days_from_civil(year, month, day);
+    let local_seconds =
+        days * 86_400 + i128::from(hour) * 3_600 + i128::from(minute) * 60 + i128::from(second);
+    Some((
+        local_seconds - i128::from(offset_minutes) * 60,
+        normalize_fraction(&fraction),
+    ))
+}
+
+fn time_to_utc_tuple(value: &str) -> Option<(i128, String)> {
+    let (hour, minute, second, fraction, offset_minutes) = parse_xsd_time_parts(value)?;
+    let local_seconds = i128::from(hour) * 3_600 + i128::from(minute) * 60 + i128::from(second);
+    Some((
+        local_seconds - i128::from(offset_minutes) * 60,
+        normalize_fraction(&fraction),
+    ))
+}
+
+fn compare_utc_tuple(left: &(i128, String), right: &(i128, String)) -> Ordering {
+    match left.0.cmp(&right.0) {
+        Ordering::Equal => compare_fraction(&left.1, &right.1),
+        ord => ord,
+    }
+}
+
+fn normalize_fraction(fraction: &str) -> String {
+    fraction.trim_end_matches('0').to_string()
+}
+
+fn compare_fraction(left: &str, right: &str) -> Ordering {
+    let max_len = left.len().max(right.len());
+    let mut left = left.to_string();
+    let mut right = right.to_string();
+    left.extend(std::iter::repeat_n('0', max_len - left.len()));
+    right.extend(std::iter::repeat_n('0', max_len - right.len()));
+    left.cmp(&right)
+}
+
+fn parse_xsd_date_parts(date: &str) -> Option<(i128, u32, u32)> {
+    let (negative, rest) = date
+        .strip_prefix('-')
+        .map(|s| (true, s))
+        .unwrap_or((false, date));
+    let mut parts = rest.split('-');
+    let year_str = parts.next()?;
+    let month_str = parts.next()?;
+    let day_str = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let year: i128 = year_str.parse().ok()?;
+    let month: u32 = month_str.parse().ok()?;
+    let day: u32 = day_str.parse().ok()?;
+    Some((if negative { -year } else { year }, month, day))
+}
+
+fn parse_xsd_time_parts(time: &str) -> Option<(u32, u32, u32, String, i32)> {
+    let (time, offset_minutes) = split_time_offset(time)?;
+    let mut parts = time.split(':');
+    let hour: u32 = parts.next()?.parse().ok()?;
+    let minute: u32 = parts.next()?.parse().ok()?;
+    let second_part = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let (second_str, frac_str) = second_part.split_once('.').unwrap_or((second_part, ""));
+    let second: u32 = second_str.parse().ok()?;
+    if !frac_str.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some((hour, minute, second, frac_str.to_string(), offset_minutes))
+}
+
+fn split_time_offset(time: &str) -> Option<(&str, i32)> {
+    if let Some(stripped) = time.strip_suffix('Z') {
+        return Some((stripped, 0));
+    }
+    if time.len() >= 6 {
+        let tz_start = time.len() - 6;
+        let tz = &time[tz_start..];
+        let sign = match tz.as_bytes().first()? {
+            b'+' => 1,
+            b'-' => -1,
+            _ => return Some((time, 0)),
+        };
+        if tz.as_bytes().get(3) != Some(&b':') {
+            return None;
+        }
+        let hours: i32 = tz[1..3].parse().ok()?;
+        let minutes: i32 = tz[4..6].parse().ok()?;
+        return Some((&time[..tz_start], sign * (hours * 60 + minutes)));
+    }
+    Some((time, 0))
+}
+
+fn days_from_civil(year: i128, month: u32, day: u32) -> i128 {
+    let mut y = year;
+    let m = i128::from(month);
+    y -= i128::from(month <= 2);
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (m + if m > 2 { -3 } else { 9 }) + 2) / 5 + i128::from(day) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+fn push_facet_compare_error(
+    facet_name: &str,
+    value: &str,
+    facet_value: &str,
+    doc: &Document,
+    node: NodeId,
+    errors: &mut Vec<ValidationError>,
+) {
+    errors.push(ValidationError {
+        message: format!(
+            "Cannot compare value '{}' with {} {} for this datatype",
+            value, facet_name, facet_value
+        ),
+        line: Some(doc.node_line(node)),
+        column: Some(doc.node_column(node)),
+    });
+}
+
 /// Check if a string is a valid QName (prefix:localname or just localname).
 /// Both prefix and localname must be valid NCNames.
 /// Covers MS tests: QName001/004/005/007/008/010/011
@@ -679,6 +853,16 @@ pub(crate) fn validate_builtin_value(
                     line: Some(doc.node_line(node)),
                     column: Some(doc.node_column(node)),
                 });
+            } else if let Some(colon_pos) = v.find(':') {
+                let prefix = &v[..colon_pos];
+                let resolver = build_resolver_for_node(doc, node);
+                if resolver.resolve(prefix).is_none() {
+                    errors.push(ValidationError {
+                        message: format!("QName prefix '{}' is not bound", prefix),
+                        line: Some(doc.node_line(node)),
+                        column: Some(doc.node_column(node)),
+                    });
+                }
             }
         }
     }
@@ -738,14 +922,20 @@ pub(crate) fn validate_list_facet(
         }
         Facet::Pattern(pattern) => {
             // Pattern facets on lists apply to the whole collapsed space-separated value
-            if let Ok(re) = XsdRegex::compile(pattern) {
-                if !re.is_match(text) {
+            match XsdRegex::compile(pattern) {
+                Ok(re) if !re.is_match(text) => {
                     errors.push(ValidationError {
                         message: format!("Value '{}' does not match pattern '{}'", text, pattern),
                         line: Some(doc.node_line(node)),
                         column: Some(doc.node_column(node)),
                     });
                 }
+                Ok(_) => {}
+                Err(e) => errors.push(ValidationError {
+                    message: format!("Pattern facet '{}' could not be compiled: {}", pattern, e),
+                    line: Some(doc.node_line(node)),
+                    column: Some(doc.node_column(node)),
+                }),
             }
         }
         Facet::WhiteSpace(_) => {}
@@ -864,9 +1054,17 @@ pub(crate) fn validate_facet(
             }
         }
         Facet::Enumeration(values) => {
-            let text_normalized = normalize_datetime_tz(text.trim());
+            let text_normalized = if is_date_time_type(base_type) {
+                normalize_datetime_tz(text.trim())
+            } else {
+                text.trim().to_string()
+            };
             let match_found = values.iter().any(|v| {
-                let v_normalized = normalize_datetime_tz(v.trim());
+                let v_normalized = if is_date_time_type(base_type) {
+                    normalize_datetime_tz(v.trim())
+                } else {
+                    v.trim().to_string()
+                };
                 v_normalized == text_normalized
             });
             if !match_found {
@@ -877,27 +1075,30 @@ pub(crate) fn validate_facet(
                 });
             }
         }
-        Facet::MinInclusive(min) => {
-            if compare_values(text.trim(), min) == Ordering::Less {
+        Facet::MinInclusive(min) => match compare_facet_values(text.trim(), min, base_type) {
+            Some(Ordering::Less) => {
                 errors.push(ValidationError {
                     message: format!("Value '{}' is less than minInclusive {}", text.trim(), min),
                     line: Some(doc.node_line(node)),
                     column: Some(doc.node_column(node)),
                 });
             }
-        }
-        Facet::MaxInclusive(max) => {
-            if compare_values(text.trim(), max) == Ordering::Greater {
+            Some(_) => {}
+            None => push_facet_compare_error("minInclusive", text.trim(), min, doc, node, errors),
+        },
+        Facet::MaxInclusive(max) => match compare_facet_values(text.trim(), max, base_type) {
+            Some(Ordering::Greater) => {
                 errors.push(ValidationError {
                     message: format!("Value '{}' exceeds maxInclusive {}", text.trim(), max),
                     line: Some(doc.node_line(node)),
                     column: Some(doc.node_column(node)),
                 });
             }
-        }
-        Facet::MinExclusive(min) => {
-            let cmp = compare_values(text.trim(), min);
-            if cmp == Ordering::Less || cmp == Ordering::Equal {
+            Some(_) => {}
+            None => push_facet_compare_error("maxInclusive", text.trim(), max, doc, node, errors),
+        },
+        Facet::MinExclusive(min) => match compare_facet_values(text.trim(), min, base_type) {
+            Some(Ordering::Less | Ordering::Equal) => {
                 errors.push(ValidationError {
                     message: format!(
                         "Value '{}' is not greater than minExclusive {}",
@@ -908,10 +1109,11 @@ pub(crate) fn validate_facet(
                     column: Some(doc.node_column(node)),
                 });
             }
-        }
-        Facet::MaxExclusive(max) => {
-            let cmp = compare_values(text.trim(), max);
-            if cmp == Ordering::Greater || cmp == Ordering::Equal {
+            Some(_) => {}
+            None => push_facet_compare_error("minExclusive", text.trim(), min, doc, node, errors),
+        },
+        Facet::MaxExclusive(max) => match compare_facet_values(text.trim(), max, base_type) {
+            Some(Ordering::Greater | Ordering::Equal) => {
                 errors.push(ValidationError {
                     message: format!(
                         "Value '{}' is not less than maxExclusive {}",
@@ -922,7 +1124,9 @@ pub(crate) fn validate_facet(
                     column: Some(doc.node_column(node)),
                 });
             }
-        }
+            Some(_) => {}
+            None => push_facet_compare_error("maxExclusive", text.trim(), max, doc, node, errors),
+        },
         Facet::TotalDigits(max_digits) => {
             let digits: String = text.trim().chars().filter(|c| c.is_ascii_digit()).collect();
             if digits.len() > *max_digits {
@@ -953,19 +1157,21 @@ pub(crate) fn validate_facet(
                 }
             }
         }
-        Facet::Pattern(pattern) => {
-            if let Ok(re) = XsdRegex::compile(pattern) {
-                if !re.is_match(text) {
-                    errors.push(ValidationError {
-                        message: format!("Value '{}' does not match pattern '{}'", text, pattern),
-                        line: Some(doc.node_line(node)),
-                        column: Some(doc.node_column(node)),
-                    });
-                }
+        Facet::Pattern(pattern) => match XsdRegex::compile(pattern) {
+            Ok(re) if !re.is_match(text) => {
+                errors.push(ValidationError {
+                    message: format!("Value '{}' does not match pattern '{}'", text, pattern),
+                    line: Some(doc.node_line(node)),
+                    column: Some(doc.node_column(node)),
+                });
             }
-            // If the pattern fails to compile, we silently accept
-            // (graceful degradation for unsupported regex features)
-        }
+            Ok(_) => {}
+            Err(e) => errors.push(ValidationError {
+                message: format!("Pattern facet '{}' could not be compiled: {}", pattern, e),
+                line: Some(doc.node_line(node)),
+                column: Some(doc.node_column(node)),
+            }),
+        },
         Facet::WhiteSpace(_) => {
             // White space normalization is applied during parsing
         }

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -47,8 +47,23 @@ fn is_valid_xml_name(s: &str) -> bool {
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
 }
 
-fn is_date_time_type(base_type: &BuiltInType) -> bool {
-    matches!(base_type, BuiltInType::DateTime | BuiltInType::Time)
+/// Whether a type carries an XSD timezone/fractional-second lexical form whose
+/// enumeration values must be normalized before comparison (e.g. `...+00:00`
+/// vs `...Z`). All XSD date/time types are timezone-bearing; non-temporal types
+/// (string, etc.) must keep their lexical value so a string that merely looks
+/// like a timestamp is not silently normalized.
+fn is_temporal_type(base_type: &BuiltInType) -> bool {
+    matches!(
+        base_type,
+        BuiltInType::DateTime
+            | BuiltInType::Time
+            | BuiltInType::Date
+            | BuiltInType::GYear
+            | BuiltInType::GYearMonth
+            | BuiltInType::GMonth
+            | BuiltInType::GMonthDay
+            | BuiltInType::GDay
+    )
 }
 
 fn compare_facet_values(
@@ -1054,13 +1069,13 @@ pub(crate) fn validate_facet(
             }
         }
         Facet::Enumeration(values) => {
-            let text_normalized = if is_date_time_type(base_type) {
+            let text_normalized = if is_temporal_type(base_type) {
                 normalize_datetime_tz(text.trim())
             } else {
                 text.trim().to_string()
             };
             let match_found = values.iter().any(|v| {
-                let v_normalized = if is_date_time_type(base_type) {
+                let v_normalized = if is_temporal_type(base_type) {
                     normalize_datetime_tz(v.trim())
                 } else {
                     v.trim().to_string()

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -274,18 +274,21 @@ fn normalize_fraction(fraction: &str) -> String {
 }
 
 fn compare_fraction(left: &str, right: &str) -> Ordering {
-    let max_len = left.len().max(right.len());
-    let mut left = left.to_string();
-    let mut right = right.to_string();
-    // Zero-pad with plain loops; std::iter::repeat_n would raise the
-    // minimum supported Rust version.
-    while left.len() < max_len {
-        left.push('0');
+    // Compare digit-by-digit with an implied '0' past the shorter end. The
+    // fractional part is attacker-sized (validation allows any number of
+    // digits), so no padded copies are allocated. Both strings are ASCII
+    // digits by the time they reach a comparison.
+    let mut left = left.bytes();
+    let mut right = right.bytes();
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            (l, r) => match l.unwrap_or(b'0').cmp(&r.unwrap_or(b'0')) {
+                Ordering::Equal => {}
+                ord => return ord,
+            },
+        }
     }
-    while right.len() < max_len {
-        right.push('0');
-    }
-    left.cmp(&right)
 }
 
 fn parse_xsd_date_parts(date: &str) -> Option<(i128, u32, u32)> {

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -277,8 +277,14 @@ fn compare_fraction(left: &str, right: &str) -> Ordering {
     let max_len = left.len().max(right.len());
     let mut left = left.to_string();
     let mut right = right.to_string();
-    left.extend(std::iter::repeat_n('0', max_len - left.len()));
-    right.extend(std::iter::repeat_n('0', max_len - right.len()));
+    // Zero-pad with plain loops; std::iter::repeat_n would raise the
+    // minimum supported Rust version.
+    while left.len() < max_len {
+        left.push('0');
+    }
+    while right.len() < max_len {
+        right.push('0');
+    }
     left.cmp(&right)
 }
 

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -274,20 +274,25 @@ fn normalize_fraction(fraction: &str) -> String {
 }
 
 fn compare_fraction(left: &str, right: &str) -> Ordering {
-    // Compare digit-by-digit with an implied '0' past the shorter end. The
+    // Digit-wise comparison with an implied '0' past the shorter end. The
     // fractional part is attacker-sized (validation allows any number of
-    // digits), so no padded copies are allocated. Both strings are ASCII
-    // digits by the time they reach a comparison.
-    let mut left = left.bytes();
-    let mut right = right.bytes();
-    loop {
-        match (left.next(), right.next()) {
-            (None, None) => return Ordering::Equal,
-            (l, r) => match l.unwrap_or(b'0').cmp(&r.unwrap_or(b'0')) {
-                Ordering::Equal => {}
-                ord => return ord,
-            },
-        }
+    // digits), so nothing is allocated: the shared prefix is an ordered byte
+    // slice comparison (lowered to SIMD-optimized memcmp) and the leftover
+    // tail only decides the ordering if it contains a non-zero digit. Both
+    // strings are ASCII digits by the time they reach a comparison.
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let shared = left.len().min(right.len());
+    match left[..shared].cmp(&right[..shared]) {
+        Ordering::Equal => {}
+        ord => return ord,
+    }
+    if left[shared..].iter().any(|&b| b != b'0') {
+        Ordering::Greater
+    } else if right[shared..].iter().any(|&b| b != b'0') {
+        Ordering::Less
+    } else {
+        Ordering::Equal
     }
 }
 

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -66,6 +66,20 @@ fn is_temporal_type(base_type: &BuiltInType) -> bool {
     )
 }
 
+/// Range-validate a value against a date-like temporal base type, so an invalid
+/// facet bound (e.g. `--99` gMonth) is rejected instead of compared lexically.
+fn is_valid_date_like(s: &str, base_type: &BuiltInType) -> bool {
+    match base_type {
+        BuiltInType::Date => is_valid_date(s),
+        BuiltInType::GYear => is_valid_gyear(s),
+        BuiltInType::GYearMonth => is_valid_gyearmonth(s),
+        BuiltInType::GMonth => is_valid_gmonth(s),
+        BuiltInType::GMonthDay => is_valid_gmonthday(s),
+        BuiltInType::GDay => is_valid_gday(s),
+        _ => true,
+    }
+}
+
 fn compare_facet_values(
     value: &str,
     facet_value: &str,
@@ -79,7 +93,16 @@ fn compare_facet_values(
         | BuiltInType::GYearMonth
         | BuiltInType::GMonth
         | BuiltInType::GMonthDay
-        | BuiltInType::GDay => Some(value.cmp(facet_value)),
+        | BuiltInType::GDay => {
+            // Fail closed on lexically-parseable but out-of-range operands, as
+            // compare_datetime_values/compare_time_values do. A raw comparison of
+            // an invalid facet bound would otherwise silently accept instances.
+            if !is_valid_date_like(value, base_type) || !is_valid_date_like(facet_value, base_type)
+            {
+                return None;
+            }
+            Some(value.cmp(facet_value))
+        }
         _ => Some(compare_values(value, facet_value)),
     }
 }

--- a/src/xsd/builtins.rs
+++ b/src/xsd/builtins.rs
@@ -80,6 +80,25 @@ fn is_valid_date_like(s: &str, base_type: &BuiltInType) -> bool {
     }
 }
 
+/// A temporal value placed on the timeline: `seconds` is UTC-normalized when
+/// the lexical form carries a timezone, otherwise local. Local vs UTC-normalized
+/// instants are only partially ordered (see `compare_temporal_instants`).
+struct TemporalInstant {
+    seconds: i128,
+    fraction: String,
+    has_tz: bool,
+}
+
+/// Maximum timezone offset (14:00) in seconds. Per the XSD order relation on
+/// dateTime (Part 2 section 3.2.7.4), a timezone-less value compared against a
+/// timezoned one is determinate only when they are more than this far apart.
+const MAX_TZ_OFFSET_SECONDS: i128 = 14 * 3_600;
+
+/// Reference year used to place the recurring gMonth/gMonthDay/gDay types on
+/// the timeline for comparison (a leap year, so --02-29 is representable),
+/// mirroring the XSD 1.1 timeline mapping.
+const G_TYPE_REFERENCE_YEAR: i128 = 1972;
+
 fn compare_facet_values(
     value: &str,
     facet_value: &str,
@@ -101,7 +120,9 @@ fn compare_facet_values(
             {
                 return None;
             }
-            Some(value.cmp(facet_value))
+            let left = date_like_to_instant(value, base_type)?;
+            let right = date_like_to_instant(facet_value, base_type)?;
+            compare_temporal_instants(&left, &right)
         }
         _ => Some(compare_values(value, facet_value)),
     }
@@ -115,9 +136,9 @@ fn compare_datetime_values(value: &str, facet_value: &str) -> Option<Ordering> {
     if !is_valid_datetime(value) || !is_valid_datetime(facet_value) {
         return None;
     }
-    let left = datetime_to_utc_tuple(value)?;
-    let right = datetime_to_utc_tuple(facet_value)?;
-    Some(compare_utc_tuple(&left, &right))
+    let left = datetime_to_instant(value)?;
+    let right = datetime_to_instant(facet_value)?;
+    compare_temporal_instants(&left, &right)
 }
 
 fn compare_time_values(value: &str, facet_value: &str) -> Option<Ordering> {
@@ -126,36 +147,124 @@ fn compare_time_values(value: &str, facet_value: &str) -> Option<Ordering> {
     if !is_valid_time(value) || !is_valid_time(facet_value) {
         return None;
     }
-    let left = time_to_utc_tuple(value)?;
-    let right = time_to_utc_tuple(facet_value)?;
-    Some(compare_utc_tuple(&left, &right))
+    let left = time_to_instant(value)?;
+    let right = time_to_instant(facet_value)?;
+    compare_temporal_instants(&left, &right)
 }
 
-fn datetime_to_utc_tuple(value: &str) -> Option<(i128, String)> {
+fn datetime_to_instant(value: &str) -> Option<TemporalInstant> {
     let (date, time) = value.split_once('T')?;
     let (year, month, day) = parse_xsd_date_parts(date)?;
     let (hour, minute, second, fraction, offset_minutes) = parse_xsd_time_parts(time)?;
     let days = days_from_civil(year, month, day);
     let local_seconds =
         days * 86_400 + i128::from(hour) * 3_600 + i128::from(minute) * 60 + i128::from(second);
-    Some((
-        local_seconds - i128::from(offset_minutes) * 60,
-        normalize_fraction(&fraction),
-    ))
+    Some(TemporalInstant {
+        seconds: local_seconds - i128::from(offset_minutes.unwrap_or(0)) * 60,
+        fraction: normalize_fraction(&fraction),
+        has_tz: offset_minutes.is_some(),
+    })
 }
 
-fn time_to_utc_tuple(value: &str) -> Option<(i128, String)> {
+fn time_to_instant(value: &str) -> Option<TemporalInstant> {
     let (hour, minute, second, fraction, offset_minutes) = parse_xsd_time_parts(value)?;
     let local_seconds = i128::from(hour) * 3_600 + i128::from(minute) * 60 + i128::from(second);
-    Some((
-        local_seconds - i128::from(offset_minutes) * 60,
-        normalize_fraction(&fraction),
-    ))
+    Some(TemporalInstant {
+        seconds: local_seconds - i128::from(offset_minutes.unwrap_or(0)) * 60,
+        fraction: normalize_fraction(&fraction),
+        has_tz: offset_minutes.is_some(),
+    })
 }
 
-fn compare_utc_tuple(left: &(i128, String), right: &(i128, String)) -> Ordering {
-    match left.0.cmp(&right.0) {
-        Ordering::Equal => compare_fraction(&left.1, &right.1),
+/// Map a date-like temporal value (date, gYear, gYearMonth, gMonth, gMonthDay,
+/// gDay) onto the timeline as the starting instant of its period, so ordering
+/// honors timezone offsets and numeric years instead of lexical form.
+fn date_like_to_instant(value: &str, base_type: &BuiltInType) -> Option<TemporalInstant> {
+    let (body, offset_minutes) = split_tz_suffix(value);
+    let (year, month, day) = match base_type {
+        BuiltInType::Date => parse_xsd_date_parts(body)?,
+        BuiltInType::GYear => (body.parse().ok()?, 1, 1),
+        BuiltInType::GYearMonth => {
+            let (year, month) = body.rsplit_once('-')?;
+            (year.parse().ok()?, month.parse().ok()?, 1)
+        }
+        BuiltInType::GMonth => {
+            // Accept --MM and the XSD 1.0 legacy --MM-- form.
+            let month = body.strip_prefix("--")?.trim_end_matches("--");
+            (G_TYPE_REFERENCE_YEAR, month.parse().ok()?, 1)
+        }
+        BuiltInType::GMonthDay => {
+            let (month, day) = body.strip_prefix("--")?.split_once('-')?;
+            (
+                G_TYPE_REFERENCE_YEAR,
+                month.parse().ok()?,
+                day.parse().ok()?,
+            )
+        }
+        BuiltInType::GDay => (
+            G_TYPE_REFERENCE_YEAR,
+            1,
+            body.strip_prefix("---")?.parse().ok()?,
+        ),
+        _ => return None,
+    };
+    Some(TemporalInstant {
+        seconds: days_from_civil(year, month, day) * 86_400
+            - i128::from(offset_minutes.unwrap_or(0)) * 60,
+        fraction: String::new(),
+        has_tz: offset_minutes.is_some(),
+    })
+}
+
+/// Compare two timeline instants per XSD's partial order: values that both
+/// carry (or both omit) a timezone are totally ordered; a timezone-less value
+/// against a timezoned one is determinate only when more than 14 hours apart.
+/// Indeterminate comparisons return None, which the facet checks report as an
+/// error (fail closed) instead of assuming UTC.
+fn compare_temporal_instants(left: &TemporalInstant, right: &TemporalInstant) -> Option<Ordering> {
+    match (left.has_tz, right.has_tz) {
+        (true, true) | (false, false) => Some(compare_instant_parts(
+            left.seconds,
+            &left.fraction,
+            right.seconds,
+            &right.fraction,
+        )),
+        (false, true) => {
+            // Timezone-less left could lie anywhere in [-14:00, +14:00]:
+            // left < right only if even its latest interpretation is earlier,
+            // and left > right only if even its earliest one is later.
+            if compare_instant_parts(
+                left.seconds + MAX_TZ_OFFSET_SECONDS,
+                &left.fraction,
+                right.seconds,
+                &right.fraction,
+            ) == Ordering::Less
+            {
+                Some(Ordering::Less)
+            } else if compare_instant_parts(
+                left.seconds - MAX_TZ_OFFSET_SECONDS,
+                &left.fraction,
+                right.seconds,
+                &right.fraction,
+            ) == Ordering::Greater
+            {
+                Some(Ordering::Greater)
+            } else {
+                None
+            }
+        }
+        (true, false) => compare_temporal_instants(right, left).map(Ordering::reverse),
+    }
+}
+
+fn compare_instant_parts(
+    left_seconds: i128,
+    left_fraction: &str,
+    right_seconds: i128,
+    right_fraction: &str,
+) -> Ordering {
+    match left_seconds.cmp(&right_seconds) {
+        Ordering::Equal => compare_fraction(left_fraction, right_fraction),
         ord => ord,
     }
 }
@@ -191,8 +300,8 @@ fn parse_xsd_date_parts(date: &str) -> Option<(i128, u32, u32)> {
     Some((if negative { -year } else { year }, month, day))
 }
 
-fn parse_xsd_time_parts(time: &str) -> Option<(u32, u32, u32, String, i32)> {
-    let (time, offset_minutes) = split_time_offset(time)?;
+fn parse_xsd_time_parts(time: &str) -> Option<(u32, u32, u32, String, Option<i32>)> {
+    let (time, offset_minutes) = split_tz_suffix(time);
     let mut parts = time.split(':');
     let hour: u32 = parts.next()?.parse().ok()?;
     let minute: u32 = parts.next()?.parse().ok()?;
@@ -208,26 +317,37 @@ fn parse_xsd_time_parts(time: &str) -> Option<(u32, u32, u32, String, i32)> {
     Some((hour, minute, second, frac_str.to_string(), offset_minutes))
 }
 
-fn split_time_offset(time: &str) -> Option<(&str, i32)> {
-    if let Some(stripped) = time.strip_suffix('Z') {
-        return Some((stripped, 0));
+/// Split an optional trailing timezone (`Z` or `+hh:mm`/`-hh:mm`) from a
+/// temporal lexical form. Returns the remaining body and the offset in
+/// minutes; a missing timezone is `None`, not UTC. Unrecognized suffixes are
+/// left in the body, where the callers' numeric parsing fails closed (the
+/// overall lexical form is range-validated separately before comparison).
+fn split_tz_suffix(s: &str) -> (&str, Option<i32>) {
+    if let Some(stripped) = s.strip_suffix('Z') {
+        return (stripped, Some(0));
     }
-    if time.len() >= 6 {
-        let tz_start = time.len() - 6;
-        let tz = &time[tz_start..];
-        let sign = match tz.as_bytes().first()? {
+    if s.len() >= 6 {
+        let tz_start = s.len() - 6;
+        let tz = &s.as_bytes()[tz_start..];
+        if !tz.is_ascii() {
+            return (s, None);
+        }
+        let sign = match tz[0] {
             b'+' => 1,
             b'-' => -1,
-            _ => return Some((time, 0)),
+            _ => return (s, None),
         };
-        if tz.as_bytes().get(3) != Some(&b':') {
-            return None;
+        if tz[3] != b':' {
+            return (s, None);
         }
-        let hours: i32 = tz[1..3].parse().ok()?;
-        let minutes: i32 = tz[4..6].parse().ok()?;
-        return Some((&time[..tz_start], sign * (hours * 60 + minutes)));
+        if let (Ok(hours), Ok(minutes)) = (
+            s[tz_start + 1..tz_start + 3].parse::<i32>(),
+            s[tz_start + 4..].parse::<i32>(),
+        ) {
+            return (&s[..tz_start], Some(sign * (hours * 60 + minutes)));
+        }
     }
-    Some((time, 0))
+    (s, None)
 }
 
 fn days_from_civil(year: i128, month: u32, day: u32) -> i128 {

--- a/src/xsd/composition.rs
+++ b/src/xsd/composition.rs
@@ -561,10 +561,13 @@ fn chameleon_fixup_type_def(td: &mut TypeDef, target_ns: &Option<String>) {
 
 /// Fix up attribute uses for chameleon include: references to the module's
 /// global attributes follow those globals into the including schema's target
-/// namespace, while local unqualified declarations stay in no namespace.
+/// namespace, and local uses qualified via `form`/`attributeFormDefault`
+/// (whose namespace was None because the module had no targetNamespace) take
+/// the target namespace as well. Local unqualified declarations stay in no
+/// namespace.
 fn chameleon_fixup_attribute_decls(attributes: &mut [AttributeDecl], target_ns: &Option<String>) {
     for attr in attributes {
-        if attr.is_ref && attr.namespace.is_none() {
+        if (attr.is_ref || attr.qualified) && attr.namespace.is_none() {
             attr.namespace = target_ns.clone();
         }
     }

--- a/src/xsd/composition.rs
+++ b/src/xsd/composition.rs
@@ -35,7 +35,8 @@ use super::parser::{
     parse_attribute_group_def, parse_complex_type, parse_model_group_def, parse_simple_type,
 };
 use super::types::{
-    ContentModel, ElementDecl, Particle, ParticleKind, TypeDef, TypeRef, XsdValidator,
+    AttributeDecl, ContentModel, ElementDecl, Particle, ParticleKind, TypeDef, TypeRef,
+    XsdValidator,
 };
 use super::XS_NAMESPACE;
 
@@ -481,18 +482,25 @@ fn merge_external_declarations(validator: &mut XsdValidator, ext: &XsdValidator,
 
     for (key, attr) in &ext.global_attributes {
         let new_key = rekey(key);
+        let mut new_attr = attr.clone();
+        // Chameleon: global attributes take on the including schema's target
+        // namespace, matching their re-keyed lookup entry.
+        if chameleon && new_attr.namespace.is_none() {
+            new_attr.namespace = target_ns.clone();
+        }
         validator
             .global_attributes
             .entry(new_key)
-            .or_insert(attr.clone());
+            .or_insert(new_attr);
     }
 
     for (key, ag) in &ext.attribute_groups {
         let new_key = rekey(key);
-        validator
-            .attribute_groups
-            .entry(new_key)
-            .or_insert(ag.clone());
+        let mut new_ag = ag.clone();
+        if chameleon {
+            chameleon_fixup_attribute_decls(&mut new_ag.attributes, &target_ns);
+        }
+        validator.attribute_groups.entry(new_key).or_insert(new_ag);
     }
 
     for (key, mg) in &ext.model_groups {
@@ -531,7 +539,8 @@ fn chameleon_fixup_type_ref(type_ref: &mut TypeRef, target_ns: &Option<String>) 
 }
 
 /// Fix up a type definition for chameleon include.
-/// For complex types, fixes the `base_type` reference and recurses into the content model.
+/// For complex types, fixes the `base_type` reference, the attribute uses,
+/// and recurses into the content model.
 fn chameleon_fixup_type_def(td: &mut TypeDef, target_ns: &Option<String>) {
     match td {
         TypeDef::Complex(ref mut ct) => {
@@ -541,10 +550,22 @@ fn chameleon_fixup_type_def(td: &mut TypeDef, target_ns: &Option<String>) {
                     *ns = target_ns.clone();
                 }
             }
+            chameleon_fixup_attribute_decls(&mut ct.attributes, target_ns);
             chameleon_fixup_content_model(&mut ct.content, target_ns);
         }
         TypeDef::Simple(_) => {
             // Simple types don't reference namespaced components that need fixing
+        }
+    }
+}
+
+/// Fix up attribute uses for chameleon include: references to the module's
+/// global attributes follow those globals into the including schema's target
+/// namespace, while local unqualified declarations stay in no namespace.
+fn chameleon_fixup_attribute_decls(attributes: &mut [AttributeDecl], target_ns: &Option<String>) {
+    for attr in attributes {
+        if attr.is_ref && attr.namespace.is_none() {
+            attr.namespace = target_ns.clone();
         }
     }
 }

--- a/src/xsd/datetime.rs
+++ b/src/xsd/datetime.rs
@@ -352,7 +352,7 @@ pub(crate) fn is_valid_date(s: &str) -> bool {
     let parts: Vec<&str> = s.split('-').collect();
     // Handle negative years
     if s.starts_with('-') {
-        if parts.len() < 4 {
+        if parts.len() != 4 {
             return false;
         }
         // parts[0] is empty, parts[1] is year, parts[2] month, parts[3] day

--- a/src/xsd/identity.rs
+++ b/src/xsd/identity.rs
@@ -60,17 +60,22 @@ impl XsdValidator {
                         .unwrap_or(&constraint.namespaces);
                     let (value, match_count, source_node) =
                         idc_evaluate_field(doc, sel_node, field_xpath, field_namespaces);
-                    // For xs:key (and xs:unique), if a field selects more than one node,
-                    // that's an error per XSD spec §3.11.4
-                    if match_count > 1 && constraint.kind == IdentityConstraintKind::Key {
+                    // For xs:key and xs:unique, if a field selects more than one node,
+                    // that's an error per XSD spec §3.11.4.
+                    if match_count > 1 {
                         let elem_name = doc
                             .element(sel_node)
                             .map(|e| &*e.name.local_name)
                             .unwrap_or("?");
+                        let kind_str = match constraint.kind {
+                            IdentityConstraintKind::Key => "Key",
+                            IdentityConstraintKind::Unique => "Unique",
+                            _ => "Constraint",
+                        };
                         errors.push(ValidationError {
                             message: format!(
-                                "Key '{}': field '{}' selects {} nodes for element '{}' (must select at most one)",
-                                constraint.name, field_xpath, match_count, elem_name
+                                "{} '{}': field '{}' selects {} nodes for element '{}' (must select at most one)",
+                                kind_str, constraint.name, field_xpath, match_count, elem_name
                             ),
                             line: Some(doc.node_line(sel_node)),
                             column: Some(doc.node_column(sel_node)),
@@ -206,8 +211,24 @@ impl XsdValidator {
                         .field_namespaces
                         .get(field_index)
                         .unwrap_or(&constraint.namespaces);
-                    let (value, _match_count, source_node) =
+                    let (value, match_count, source_node) =
                         idc_evaluate_field(doc, sel_node, field_xpath, field_namespaces);
+                    if match_count > 1 {
+                        let elem_name = doc
+                            .element(sel_node)
+                            .map(|e| &*e.name.local_name)
+                            .unwrap_or("?");
+                        errors.push(ValidationError {
+                            message: format!(
+                                "KeyRef '{}': field '{}' selects {} nodes for element '{}' (must select at most one)",
+                                constraint.name, field_xpath, match_count, elem_name
+                            ),
+                            line: Some(doc.node_line(sel_node)),
+                            column: Some(doc.node_column(sel_node)),
+                        });
+                        all_present = false;
+                        break;
+                    }
                     if value.is_none() {
                         all_present = false;
                     }

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -1185,6 +1185,29 @@ fn parse_particles(
     Ok(particles)
 }
 
+/// Whether a local `name=` attribute declaration is namespace-qualified.
+///
+/// Per XSD Part 1 §3.2.2, a local attribute use takes the schema target
+/// namespace when its `form` attribute is `qualified`, or when `form` is
+/// absent and the enclosing `xs:schema` sets `attributeFormDefault="qualified"`.
+fn local_attribute_is_qualified(doc: &Document, node: NodeId) -> bool {
+    if let Some(NodeKind::Element(elem)) = doc.node_kind(node) {
+        if let Some(form) = elem.get_attribute("form") {
+            return form == "qualified";
+        }
+    }
+    let mut current = doc.parent(node);
+    while let Some(ancestor) = current {
+        if let Some(NodeKind::Element(e)) = doc.node_kind(ancestor) {
+            if e.name.local_name == "schema" {
+                return e.get_attribute("attributeFormDefault") == Some("qualified");
+            }
+        }
+        current = doc.parent(ancestor);
+    }
+    false
+}
+
 /// Parse an `<xs:attribute>` declaration into an `AttributeDecl`.
 ///
 /// Handles both `name` and `ref` attributes, inline `<xs:simpleType>` children,
@@ -1200,7 +1223,12 @@ fn parse_attribute_decl(
 
     // Handle <attribute ref="..."/> — create a placeholder decl with the ref name
     let (name, namespace) = if let Some(n) = elem.get_attribute("name") {
-        (n.to_string(), None)
+        let namespace = if local_attribute_is_qualified(doc, node) {
+            schema_target_ns.clone()
+        } else {
+            None
+        };
+        (n.to_string(), namespace)
     } else if let Some(ref_name) = elem.get_attribute("ref") {
         (
             strip_prefix(ref_name).to_string(),

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -820,6 +820,7 @@ pub(super) fn parse_attribute_group_def(
                             // Use the global attribute declaration but allow
                             // local overrides for use/required
                             let mut attr = global_attr.clone();
+                            attr.is_ref = true;
                             if child_elem.get_attribute("use") == Some("required") {
                                 attr.required = true;
                             } else if child_elem.get_attribute("use") == Some("prohibited") {
@@ -837,6 +838,7 @@ pub(super) fn parse_attribute_group_def(
                                 required,
                                 default: None,
                                 prohibited,
+                                is_ref: true,
                             });
                         }
                     } else {
@@ -1226,17 +1228,18 @@ fn parse_attribute_decl(
         .ok_or_else(|| XmlError::validation("Expected element node for attribute declaration"))?;
 
     // Handle <attribute ref="..."/> — create a placeholder decl with the ref name
-    let (name, namespace) = if let Some(n) = elem.get_attribute("name") {
+    let (name, namespace, is_ref) = if let Some(n) = elem.get_attribute("name") {
         let namespace = if local_attribute_is_qualified(doc, node) {
             schema_target_ns.clone()
         } else {
             None
         };
-        (n.to_string(), namespace)
+        (n.to_string(), namespace, false)
     } else if let Some(ref_name) = elem.get_attribute("ref") {
         (
             strip_prefix(ref_name).to_string(),
             resolve_ref_namespace(doc, node, ref_name, schema_target_ns),
+            true,
         )
     } else {
         return Err(XmlError::validation(
@@ -1274,6 +1277,7 @@ fn parse_attribute_decl(
         required,
         default,
         prohibited,
+        is_ref,
     })
 }
 

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -1192,8 +1192,12 @@ fn parse_particles(
 /// absent and the enclosing `xs:schema` sets `attributeFormDefault="qualified"`.
 fn local_attribute_is_qualified(doc: &Document, node: NodeId) -> bool {
     if let Some(NodeKind::Element(elem)) = doc.node_kind(node) {
-        if let Some(form) = elem.get_attribute("form") {
-            return form == "qualified";
+        // Match parse_element_decl: only an explicit qualified/unqualified
+        // overrides the schema default; unknown form values fall through.
+        match elem.get_attribute("form") {
+            Some("qualified") => return true,
+            Some("unqualified") => return false,
+            _ => {}
         }
     }
     let mut current = doc.parent(node);

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -528,7 +528,7 @@ pub(super) fn parse_complex_type(
                     }
                 }
                 "attribute" => {
-                    attributes.push(parse_attribute_decl(doc, child)?);
+                    attributes.push(parse_attribute_decl(doc, child, target_ns)?);
                 }
                 "anyAttribute" => {
                     let new_wc = parse_any_attribute(child_elem, target_ns);
@@ -605,8 +605,9 @@ pub(super) fn parse_complex_type(
                                             }
                                             match gc_child_elem.name.local_name.as_ref() {
                                                 "attribute" => {
-                                                    attributes
-                                                        .push(parse_attribute_decl(doc, gc_child)?);
+                                                    attributes.push(parse_attribute_decl(
+                                                        doc, gc_child, target_ns,
+                                                    )?);
                                                 }
                                                 "anyAttribute" => {
                                                     local_wildcard = Some(parse_any_attribute(
@@ -831,6 +832,7 @@ pub(super) fn parse_attribute_group_def(
                             let prohibited = child_elem.get_attribute("use") == Some("prohibited");
                             attributes.push(AttributeDecl {
                                 name: local_name.to_string(),
+                                namespace: key.0.clone(),
                                 type_ref: TypeRef::BuiltIn(BuiltInType::String),
                                 required,
                                 default: None,
@@ -838,7 +840,7 @@ pub(super) fn parse_attribute_group_def(
                             });
                         }
                     } else {
-                        attributes.push(parse_attribute_decl(doc, child)?);
+                        attributes.push(parse_attribute_decl(doc, child, target_ns)?);
                     }
                 }
                 "attributeGroup" => {
@@ -1187,16 +1189,23 @@ fn parse_particles(
 ///
 /// Handles both `name` and `ref` attributes, inline `<xs:simpleType>` children,
 /// `use` (required/prohibited), and `default`.
-fn parse_attribute_decl(doc: &Document, node: NodeId) -> XmlResult<AttributeDecl> {
+fn parse_attribute_decl(
+    doc: &Document,
+    node: NodeId,
+    schema_target_ns: &Option<String>,
+) -> XmlResult<AttributeDecl> {
     let elem = doc
         .element(node)
         .ok_or_else(|| XmlError::validation("Expected element node for attribute declaration"))?;
 
     // Handle <attribute ref="..."/> — create a placeholder decl with the ref name
-    let name = if let Some(n) = elem.get_attribute("name") {
-        n.to_string()
+    let (name, namespace) = if let Some(n) = elem.get_attribute("name") {
+        (n.to_string(), None)
     } else if let Some(ref_name) = elem.get_attribute("ref") {
-        strip_prefix(ref_name).to_string()
+        (
+            strip_prefix(ref_name).to_string(),
+            resolve_ref_namespace(doc, node, ref_name, schema_target_ns),
+        )
     } else {
         return Err(XmlError::validation(
             "Attribute declaration missing 'name' or 'ref' attribute",
@@ -1228,6 +1237,7 @@ fn parse_attribute_decl(doc: &Document, node: NodeId) -> XmlResult<AttributeDecl
 
     Ok(AttributeDecl {
         name,
+        namespace,
         type_ref,
         required,
         default,

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -839,6 +839,7 @@ pub(super) fn parse_attribute_group_def(
                                 default: None,
                                 prohibited,
                                 is_ref: true,
+                                qualified: false,
                             });
                         }
                     } else {
@@ -1228,18 +1229,20 @@ fn parse_attribute_decl(
         .ok_or_else(|| XmlError::validation("Expected element node for attribute declaration"))?;
 
     // Handle <attribute ref="..."/> — create a placeholder decl with the ref name
-    let (name, namespace, is_ref) = if let Some(n) = elem.get_attribute("name") {
-        let namespace = if local_attribute_is_qualified(doc, node) {
+    let (name, namespace, is_ref, qualified) = if let Some(n) = elem.get_attribute("name") {
+        let qualified = local_attribute_is_qualified(doc, node);
+        let namespace = if qualified {
             schema_target_ns.clone()
         } else {
             None
         };
-        (n.to_string(), namespace, false)
+        (n.to_string(), namespace, false, qualified)
     } else if let Some(ref_name) = elem.get_attribute("ref") {
         (
             strip_prefix(ref_name).to_string(),
             resolve_ref_namespace(doc, node, ref_name, schema_target_ns),
             true,
+            false,
         )
     } else {
         return Err(XmlError::validation(
@@ -1278,6 +1281,7 @@ fn parse_attribute_decl(
         default,
         prohibited,
         is_ref,
+        qualified,
     })
 }
 

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -369,6 +369,10 @@ pub(crate) struct AttributeDecl {
     #[allow(dead_code)]
     pub(super) default: Option<String>,
     pub(super) prohibited: bool,
+    /// Whether this use came from `ref=` (a global attribute reference). Under
+    /// chameleon include, ref'd no-namespace attributes move to the including
+    /// schema's target namespace while local unqualified ones stay unqualified.
+    pub(super) is_ref: bool,
 }
 
 /// A simple type definition.

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -373,6 +373,11 @@ pub(crate) struct AttributeDecl {
     /// chameleon include, ref'd no-namespace attributes move to the including
     /// schema's target namespace while local unqualified ones stay unqualified.
     pub(super) is_ref: bool,
+    /// Whether a local (`name=`) use was namespace-qualified via
+    /// `form="qualified"` or `attributeFormDefault="qualified"`. Persisted so
+    /// chameleon include can move qualified local uses of a no-namespace
+    /// module into the including schema's target namespace.
+    pub(super) qualified: bool,
 }
 
 /// A simple type definition.

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -362,6 +362,7 @@ pub(crate) enum MaxOccurs {
 #[derive(Debug, Clone)]
 pub(crate) struct AttributeDecl {
     pub(super) name: String,
+    pub(super) namespace: Option<String>,
     pub(super) type_ref: TypeRef,
     pub(super) required: bool,
     /// Default value (parsed for spec completeness; not yet enforced during validation).

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -25,6 +25,11 @@ use super::types::*;
 use super::wildcard::wildcard_allows_namespace;
 use super::{XSI_NAMESPACE, XS_NAMESPACE};
 
+fn attr_decl_matches(attr: &crate::dom::Attribute<'_>, decl: &AttributeDecl) -> bool {
+    attr.name.local_name == decl.name
+        && attr.name.namespace_uri.as_deref() == decl.namespace.as_deref()
+}
+
 /// Result of resolving an `xsi:type` attribute on an element.
 ///
 /// When an instance element carries `xsi:type`, the validator resolves it to one of:
@@ -648,7 +653,17 @@ impl XsdValidator {
                 self.validate_element(doc, node, &resolved, errors);
                 return;
             }
-            // Fall through with the ref decl's AnyType if global not found
+            let display = decl
+                .namespace
+                .as_ref()
+                .map(|uri| format!("{{{}}}{}", uri, decl.name))
+                .unwrap_or_else(|| decl.name.clone());
+            errors.push(ValidationError {
+                message: format!("Element reference '{}' not found", display),
+                line: Some(doc.node_line(node)),
+                column: Some(doc.node_column(node)),
+            });
+            return;
         }
 
         // Reject abstract elements: they cannot appear directly in instances
@@ -994,10 +1009,15 @@ impl XsdValidator {
                     let found = elem
                         .attributes
                         .iter()
-                        .any(|a| a.name.local_name == attr_decl.name);
+                        .any(|a| attr_decl_matches(a, attr_decl));
                     if !found {
+                        let display = attr_decl
+                            .namespace
+                            .as_ref()
+                            .map(|uri| format!("{{{}}}{}", uri, attr_decl.name))
+                            .unwrap_or_else(|| attr_decl.name.clone());
                         errors.push(ValidationError {
-                            message: format!("Required attribute '{}' is missing", attr_decl.name),
+                            message: format!("Required attribute '{}' is missing", display),
                             line: Some(doc.node_line(node)),
                             column: Some(doc.node_column(node)),
                         });
@@ -1015,7 +1035,7 @@ impl XsdValidator {
                 if let Some(attr) = elem
                     .attributes
                     .iter()
-                    .find(|a| a.name.local_name == attr_decl.name)
+                    .find(|a| attr_decl_matches(a, attr_decl))
                 {
                     let value = &attr.value;
                     debug_log!(
@@ -1049,9 +1069,8 @@ impl XsdValidator {
                         continue;
                     }
                     // Skip if already matched by an explicit attribute declaration
-                    let already_declared = effective_attrs
-                        .iter()
-                        .any(|ad| ad.name == attr.name.local_name);
+                    let already_declared =
+                        effective_attrs.iter().any(|ad| attr_decl_matches(attr, ad));
                     if already_declared {
                         continue;
                     }
@@ -1080,13 +1099,7 @@ impl XsdValidator {
                         ProcessContents::Lax | ProcessContents::Strict => {
                             // Look up in global attribute declarations
                             let key = (attr_ns_str.clone(), attr.name.local_name.to_string());
-                            let global_decl = self.global_attributes.get(&key).or_else(|| {
-                                let key2 = (
-                                    self.target_namespace.clone(),
-                                    attr.name.local_name.to_string(),
-                                );
-                                self.global_attributes.get(&key2)
-                            });
+                            let global_decl = self.global_attributes.get(&key);
                             match global_decl {
                                 Some(decl) => {
                                     // Validate attribute value against its declared type
@@ -1134,9 +1147,8 @@ impl XsdValidator {
                         continue;
                     }
                     // Check if declared
-                    let already_declared = effective_attrs
-                        .iter()
-                        .any(|ad| ad.name == attr.name.local_name);
+                    let already_declared =
+                        effective_attrs.iter().any(|ad| attr_decl_matches(attr, ad));
                     if !already_declared {
                         errors.push(ValidationError {
                             message: format!(

--- a/src/xsd/validation.rs
+++ b/src/xsd/validation.rs
@@ -509,12 +509,18 @@ impl XsdValidator {
             return ct.attributes.clone();
         }
 
+        // Attribute declarations are namespace-aware: merge and override by
+        // expanded name, not local name, so declarations that share a local
+        // name across namespaces are kept distinct.
+        let same_expanded_name =
+            |a: &AttributeDecl, b: &AttributeDecl| a.name == b.name && a.namespace == b.namespace;
+
         match ct.derived_by_extension {
             Some(true) => {
                 // Extension: base attributes + derived attributes
                 let mut result = base_attrs;
                 for attr in &ct.attributes {
-                    if !result.iter().any(|a| a.name == attr.name) {
+                    if !result.iter().any(|a| same_expanded_name(a, attr)) {
                         result.push(attr.clone());
                     }
                 }
@@ -527,7 +533,10 @@ impl XsdValidator {
                 let mut result = Vec::new();
                 for base_attr in &base_attrs {
                     // Check if the restriction overrides or prohibits this attribute
-                    let override_attr = ct.attributes.iter().find(|a| a.name == base_attr.name);
+                    let override_attr = ct
+                        .attributes
+                        .iter()
+                        .find(|a| same_expanded_name(a, base_attr));
                     if let Some(oa) = override_attr {
                         // Use the overridden version (but check if prohibited)
                         if !oa.prohibited {
@@ -542,7 +551,7 @@ impl XsdValidator {
                 // Also add any new attributes from restriction that aren't in base
                 // (unusual but technically possible)
                 for attr in &ct.attributes {
-                    if !attr.prohibited && !result.iter().any(|a| a.name == attr.name) {
+                    if !attr.prohibited && !result.iter().any(|a| same_expanded_name(a, attr)) {
                         result.push(attr.clone());
                     }
                 }

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -192,9 +192,14 @@ fn validate_pi_target(target: &str) -> XmlResult<()> {
     // serialization agree on which targets are valid (the ASCII-only check here
     // previously rejected legal non-ASCII names). NCName already excludes ':'
     // and whitespace; only the reserved "xml" target needs a separate guard.
-    if !crate::writer::is_valid_xml_ncname(target) || target.eq_ignore_ascii_case("xml") {
+    if !crate::writer::is_valid_xml_ncname(target) {
         return Err(XmlError::validation(
             "xsl:processing-instruction target is not a valid NCName",
+        ));
+    }
+    if target.eq_ignore_ascii_case("xml") {
+        return Err(XmlError::validation(
+            "xsl:processing-instruction target must not be the reserved name 'xml'",
         ));
     }
     Ok(())

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -178,13 +178,13 @@ fn collect_rtf_text(node: &ResultNode, out: &mut String) {
     }
 }
 
-fn sanitize_comment_text(text: &str) -> XmlResult<String> {
+fn sanitize_comment_text(text: String) -> XmlResult<String> {
     if text.contains("--") || text.ends_with('-') {
         return Err(XmlError::validation(
             "xsl:comment content must not contain '--' or end with '-'",
         ));
     }
-    Ok(text.to_string())
+    Ok(text)
 }
 
 fn validate_pi_target(target: &str) -> XmlResult<()> {
@@ -205,13 +205,13 @@ fn validate_pi_target(target: &str) -> XmlResult<()> {
     Ok(())
 }
 
-fn sanitize_pi_data(data: &str) -> XmlResult<String> {
+fn sanitize_pi_data(data: String) -> XmlResult<String> {
     if data.contains("?>") {
         return Err(XmlError::validation(
             "xsl:processing-instruction data must not contain '?>'",
         ));
     }
-    Ok(data.to_string())
+    Ok(data)
 }
 
 // ─── Output options (xsl:output) ──────────────────────────
@@ -1452,14 +1452,14 @@ impl<'a, 'b> Engine<'a, 'b> {
             }
             Instruction::Comment { body } => {
                 let items = self.execute_sequence(body, focus)?;
-                let text = sanitize_comment_text(&rtf_string_value(&items_to_nodes(items)))?;
+                let text = sanitize_comment_text(rtf_string_value(&items_to_nodes(items)))?;
                 out.push(ResultItem::Node(ResultNode::Comment(text)));
             }
             Instruction::Pi { name, body } => {
                 let target = self.eval_avt(name, focus)?;
                 validate_pi_target(&target)?;
                 let items = self.execute_sequence(body, focus)?;
-                let data = sanitize_pi_data(&rtf_string_value(&items_to_nodes(items)))?;
+                let data = sanitize_pi_data(rtf_string_value(&items_to_nodes(items)))?;
                 out.push(ResultItem::Node(ResultNode::Pi { target, data }));
             }
             Instruction::CallTemplate { name, params } => {

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -188,18 +188,11 @@ fn sanitize_comment_text(text: &str) -> XmlResult<String> {
 }
 
 fn validate_pi_target(target: &str) -> XmlResult<()> {
-    let valid_ncname = target
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-        && target
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
-    if !valid_ncname
-        || target.eq_ignore_ascii_case("xml")
-        || target.contains(':')
-        || target.trim() != target
-    {
+    // Reuse the serializer's full-Unicode NCName check so XSLT construction and
+    // serialization agree on which targets are valid (the ASCII-only check here
+    // previously rejected legal non-ASCII names). NCName already excludes ':'
+    // and whitespace; only the reserved "xml" target needs a separate guard.
+    if !crate::writer::is_valid_xml_ncname(target) || target.eq_ignore_ascii_case("xml") {
         return Err(XmlError::validation(
             "xsl:processing-instruction target is not a valid NCName",
         ));

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -178,6 +178,44 @@ fn collect_rtf_text(node: &ResultNode, out: &mut String) {
     }
 }
 
+fn sanitize_comment_text(text: &str) -> XmlResult<String> {
+    if text.contains("--") || text.ends_with('-') {
+        return Err(XmlError::validation(
+            "xsl:comment content must not contain '--' or end with '-'",
+        ));
+    }
+    Ok(text.to_string())
+}
+
+fn validate_pi_target(target: &str) -> XmlResult<()> {
+    let valid_ncname = target
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && target
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
+    if !valid_ncname
+        || target.eq_ignore_ascii_case("xml")
+        || target.contains(':')
+        || target.trim() != target
+    {
+        return Err(XmlError::validation(
+            "xsl:processing-instruction target is not a valid NCName",
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_pi_data(data: &str) -> XmlResult<String> {
+    if data.contains("?>") {
+        return Err(XmlError::validation(
+            "xsl:processing-instruction data must not contain '?>'",
+        ));
+    }
+    Ok(data.to_string())
+}
+
 // ─── Output options (xsl:output) ──────────────────────────
 
 #[derive(Debug, Clone)]
@@ -1416,13 +1454,14 @@ impl<'a, 'b> Engine<'a, 'b> {
             }
             Instruction::Comment { body } => {
                 let items = self.execute_sequence(body, focus)?;
-                let text = rtf_string_value(&items_to_nodes(items));
+                let text = sanitize_comment_text(&rtf_string_value(&items_to_nodes(items)))?;
                 out.push(ResultItem::Node(ResultNode::Comment(text)));
             }
             Instruction::Pi { name, body } => {
                 let target = self.eval_avt(name, focus)?;
+                validate_pi_target(&target)?;
                 let items = self.execute_sequence(body, focus)?;
-                let data = rtf_string_value(&items_to_nodes(items));
+                let data = sanitize_pi_data(&rtf_string_value(&items_to_nodes(items)))?;
                 out.push(ResultItem::Node(ResultNode::Pi { target, data }));
             }
             Instruction::CallTemplate { name, params } => {

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -1073,6 +1073,88 @@ fn xsd_gyear_facet_comparison_is_numeric_not_lexical() {
 }
 
 #[test]
+fn xsd_effective_attributes_merge_by_expanded_name() {
+    // A derived type adds a qualified attribute sharing the local name of the
+    // base type's unqualified one; namespace-aware merging must keep both
+    // (name-only merging would drop the derived declaration).
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:complexType name="Base">
+    <xs:attribute name="id" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:extension base="t:Base">
+        <xs:attribute name="id" type="xs:string" use="required" form="qualified"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="r" type="t:Derived"/>
+</xs:schema>"###;
+
+    let both = r#"<t:r xmlns:t="urn:t" id="a" t:id="b"/>"#;
+    let errors = validate(schema, both);
+    assert!(
+        errors.is_empty(),
+        "both same-local-name attributes must validate, got {errors:?}"
+    );
+
+    // The qualified declaration is its own required attribute; supplying only
+    // the unqualified one must not satisfy it.
+    let missing = validate(schema, r#"<t:r xmlns:t="urn:t" id="a"/>"#);
+    assert!(
+        !missing.is_empty(),
+        "missing qualified attribute must be reported"
+    );
+}
+
+#[test]
+fn chameleon_include_qualifies_form_qualified_local_attributes() {
+    // A chameleon-included module with attributeFormDefault="qualified": its
+    // local attribute uses move into the including schema's target namespace
+    // along with everything else.
+    let dir = mkdir_unique("chameleon-form");
+
+    let module = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="att" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+    fs::write(dir.join("module.xsd"), module).unwrap();
+
+    let outer = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:chamform"
+           xmlns="urn:chamform"
+           elementFormDefault="qualified">
+  <xs:include schemaLocation="module.xsd"/>
+</xs:schema>"#;
+    let outer_path = dir.join("outer.xsd");
+    fs::write(&outer_path, outer).unwrap();
+
+    let schema_doc = parse(outer).unwrap();
+    let validator =
+        XsdValidator::from_schema_with_base_path(&schema_doc, Some(&outer_path)).unwrap();
+    let doc = parse(r#"<c:root xmlns:c="urn:chamform" c:att="yes"/>"#).unwrap();
+    let errors: Vec<String> = validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect();
+
+    fs::remove_dir_all(&dir).ok();
+    assert!(
+        errors.is_empty(),
+        "chameleon-included qualified local attribute must match target namespace, got {errors:?}"
+    );
+}
+
+#[test]
 fn xsd_unknown_attribute_form_falls_back_to_schema_default() {
     // An unrecognized form= value must not silently force the attribute to be
     // unqualified; like parse_element_decl, it falls back to the schema's

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -1245,6 +1245,59 @@ fn xslt_processing_instruction_rejects_markup_breakout() {
 }
 
 #[test]
+fn xslt_processing_instruction_target_accepts_unicode_ncname() {
+    // The PI target check must use the same full-Unicode NCName rule as the
+    // serializer, so a legal non-ASCII target is accepted rather than rejected
+    // by an ASCII-only shortcut.
+    let xslt = "<xsl:stylesheet version=\"1.0\"\n\
+           xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n\
+  <xsl:output method=\"xml\" omit-xml-declaration=\"yes\"/>\n\
+  <xsl:template match=\"/\">\n\
+    <xsl:processing-instruction name=\"caf\u{e9}\">data</xsl:processing-instruction>\n\
+  </xsl:template>\n\
+</xsl:stylesheet>";
+
+    assert_eq!(
+        uppsala::transform(xslt, "<r/>").unwrap(),
+        "<?caf\u{e9} data?>"
+    );
+}
+
+#[test]
+fn xsd_date_like_facet_comparison_fails_closed_on_invalid_bounds() {
+    // compare_facet_values must fail closed for out-of-range facet bounds on all
+    // date-like temporal types, not just xs:dateTime/xs:time. A raw lexical
+    // comparison of an invalid bound would otherwise silently accept instances.
+    let gmonth_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="m">
+    <xs:simpleType>
+      <xs:restriction base="xs:gMonth">
+        <xs:maxInclusive value="--99"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        !validate(gmonth_schema, "<m>--06</m>").is_empty(),
+        "invalid gMonth facet bound must fail closed"
+    );
+
+    let date_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="d">
+    <xs:simpleType>
+      <xs:restriction base="xs:date">
+        <xs:maxInclusive value="2024-99-01"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        !validate(date_schema, "<d>2024-06-01</d>").is_empty(),
+        "invalid date facet bound must fail closed"
+    );
+}
+
+#[test]
 fn exslt_padding_has_output_cap() {
     let xslt = r#"<xsl:stylesheet version="1.0"
            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -969,6 +969,41 @@ fn xsd_string_enumeration_is_not_datetime_normalized() {
 }
 
 #[test]
+fn xsd_temporal_enumeration_normalizes_timezone_beyond_datetime() {
+    // All timezone-bearing temporal types (not just xs:dateTime/xs:time) must
+    // normalize the timezone suffix for enumeration matching, so a lexically
+    // different but value-equivalent instant (`...+00:00` vs `...Z`) still
+    // matches an allowed enumeration value.
+    let date_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="d">
+    <xs:simpleType>
+      <xs:restriction base="xs:date">
+        <xs:enumeration value="2024-01-01Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        validate(date_schema, "<d>2024-01-01+00:00</d>").is_empty(),
+        "xs:date enumeration must normalize +00:00 to Z"
+    );
+
+    let gym_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="g">
+    <xs:simpleType>
+      <xs:restriction base="xs:gYearMonth">
+        <xs:enumeration value="2024-01Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        validate(gym_schema, "<g>2024-01+00:00</g>").is_empty(),
+        "xs:gYearMonth enumeration must normalize +00:00 to Z"
+    );
+}
+
+#[test]
 fn xsd_negative_date_rejects_extra_suffix() {
     let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="d" type="xs:date"/>

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -1458,6 +1458,37 @@ fn xslt_processing_instruction_rejects_markup_breakout() {
 }
 
 #[test]
+fn xslt_processing_instruction_target_errors_are_distinct() {
+    // The reserved "xml" target and a syntactically invalid NCName are
+    // different failures; each gets its own diagnostic.
+    let stylesheet = |name: &str| {
+        format!(
+            r#"<xsl:stylesheet version="1.0"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+  <xsl:template match="/">
+    <xsl:processing-instruction name="{name}">d</xsl:processing-instruction>
+  </xsl:template>
+</xsl:stylesheet>"#
+        )
+    };
+
+    let err = uppsala::transform(&stylesheet("xMl"), "<r/>")
+        .expect_err("reserved xml PI target must be rejected");
+    assert!(
+        err.to_string().contains("reserved name 'xml'"),
+        "expected reserved-target diagnostic, got {err:?}"
+    );
+
+    let err = uppsala::transform(&stylesheet("1bad"), "<r/>")
+        .expect_err("non-NCName PI target must be rejected");
+    assert!(
+        err.to_string().contains("not a valid NCName"),
+        "expected NCName diagnostic, got {err:?}"
+    );
+}
+
+#[test]
 fn xslt_processing_instruction_target_accepts_unicode_ncname() {
     // The PI target check must use the same full-Unicode NCName rule as the
     // serializer, so a legal non-ASCII target is accepted rather than rejected

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -586,6 +586,53 @@ fn prefixed_xsd_type_qnames_resolve_to_imported_namespace() {
 }
 
 #[test]
+fn chameleon_include_qualifies_referenced_attributes() {
+    // A no-namespace module included into a target namespace (chameleon
+    // include) moves its global attributes into that namespace; attribute
+    // uses that reference them must follow, or namespace-aware matching
+    // rejects valid instances (W3C Sun xsd024 pattern).
+    let dir = mkdir_unique("chameleon-attr");
+
+    let module = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:element name="root" type="rootType"/>
+  <xs:complexType name="rootType">
+    <xs:attributeGroup ref="attGroup"/>
+  </xs:complexType>
+  <xs:attributeGroup name="attGroup">
+    <xs:attribute ref="att"/>
+  </xs:attributeGroup>
+  <xs:attribute name="att" type="xs:string"/>
+</xs:schema>"#;
+    fs::write(dir.join("module.xsd"), module).unwrap();
+
+    let outer = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:cham"
+           xmlns="urn:cham"
+           elementFormDefault="qualified">
+  <xs:include schemaLocation="module.xsd"/>
+</xs:schema>"#;
+    let outer_path = dir.join("outer.xsd");
+    fs::write(&outer_path, outer).unwrap();
+
+    let schema_doc = parse(outer).unwrap();
+    let validator =
+        XsdValidator::from_schema_with_base_path(&schema_doc, Some(&outer_path)).unwrap();
+    let doc = parse(r#"<c:root xmlns:c="urn:cham" c:att="yes"/>"#).unwrap();
+    let errors: Vec<String> = validator
+        .validate(&doc)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect();
+
+    fs::remove_dir_all(&dir).ok();
+    assert!(
+        errors.is_empty(),
+        "chameleon-included attribute ref must match target namespace, got {errors:?}"
+    );
+}
+
+#[test]
 fn unknown_named_xsd_type_fails_closed() {
     // An unresolved schema type reference must be a validation error. Treating
     // it as string-like content would silently bypass the intended constraint.
@@ -942,6 +989,87 @@ fn xsd_attribute_form_qualified_overrides_unqualified_default() {
         !errors.is_empty(),
         "unqualified spelling must not satisfy a form=qualified declaration"
     );
+}
+
+#[test]
+fn xsd_timezone_less_temporal_facet_comparison_fails_closed() {
+    // A timezone-less facet bound and a timezoned value are only partially
+    // ordered (XSD Part 2 section 3.2.7.4); a missing timezone must not be
+    // silently treated as UTC.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="t">
+    <xs:simpleType>
+      <xs:restriction base="xs:time">
+        <xs:minInclusive value="12:00:00"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"###;
+
+    // 22:00:00-12:00 is 34:00:00 UTC-normalized: more than 14 hours after the
+    // timezone-less bound, so the order is determinate and the value is valid.
+    let errors = validate(schema, "<t>22:00:00-12:00</t>");
+    assert!(
+        errors.is_empty(),
+        "determinate cross-timezone comparison must validate, got {errors:?}"
+    );
+
+    // 13:00:00+05:00 is 08:00:00Z: within the +/-14:00 window of the
+    // timezone-less bound, so the comparison is indeterminate and must fail
+    // closed (treating the bound as UTC would wrongly accept the value).
+    let errors = validate(schema, "<t>13:00:00+05:00</t>");
+    assert!(
+        errors.iter().any(|e| e.contains("Cannot compare")),
+        "expected indeterminate comparison error, got {errors:?}"
+    );
+
+    // Both timezone-less: totally ordered, normal facet enforcement applies.
+    assert!(validate(schema, "<t>12:30:00</t>").is_empty());
+    assert!(!validate(schema, "<t>11:00:00</t>").is_empty());
+}
+
+#[test]
+fn xsd_date_facet_comparison_uses_timeline_not_lexical_order() {
+    // 2024-01-02+14:00 and 2024-01-01-10:00 denote the same instant
+    // (2024-01-01T10:00:00Z); lexical comparison would reject the value as
+    // greater than the bound.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="d">
+    <xs:simpleType>
+      <xs:restriction base="xs:date">
+        <xs:maxInclusive value="2024-01-01-10:00"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"###;
+
+    let errors = validate(schema, "<d>2024-01-02+14:00</d>");
+    assert!(
+        errors.is_empty(),
+        "timezone-normalized equal date must satisfy maxInclusive, got {errors:?}"
+    );
+    assert!(!validate(schema, "<d>2024-01-02-10:00</d>").is_empty());
+}
+
+#[test]
+fn xsd_gyear_facet_comparison_is_numeric_not_lexical() {
+    // Lexically "9999" > "10000"; on the timeline 9999 precedes 10000.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="y">
+    <xs:simpleType>
+      <xs:restriction base="xs:gYear">
+        <xs:maxInclusive value="10000"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"###;
+
+    let errors = validate(schema, "<y>9999</y>");
+    assert!(
+        errors.is_empty(),
+        "gYear must compare numerically, got {errors:?}"
+    );
+    assert!(!validate(schema, "<y>10001</y>").is_empty());
 }
 
 #[test]

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -8,7 +8,9 @@ use std::borrow::Cow;
 use std::fs;
 use std::path::PathBuf;
 
-use uppsala::{parse, Document, NodeId, QName, XPathEvaluator, XmlWriter, XsdValidator};
+use uppsala::{
+    parse, Document, NodeId, Parser, QName, Stylesheet, XPathEvaluator, XmlWriter, XsdValidator,
+};
 
 fn validate(schema: &str, instance: &str) -> Vec<String> {
     // Keep XSD assertions compact by returning display strings rather than
@@ -21,6 +23,14 @@ fn validate(schema: &str, instance: &str) -> Vec<String> {
         .into_iter()
         .map(|e| e.to_string())
         .collect()
+}
+
+fn transform_exslt(xslt: &str, xml: &str) -> uppsala::XmlResult<String> {
+    let style_doc = Parser::new().parse(xslt)?;
+    let stylesheet = Stylesheet::compile(&style_doc)?.with_exslt(true);
+    let mut source = Parser::new().parse(xml)?;
+    source.prepare_xpath();
+    stylesheet.transform(&source)
 }
 
 fn mkdir_unique(label: &str) -> PathBuf {
@@ -432,6 +442,41 @@ fn xsd_rejects_malformed_time_and_datetime_values() {
     assert!(!validate(schema, "<t>12:00:0é0+000</t>").is_empty());
     assert!(!validate(schema, "<dt>2024-01-01T12:00:00+99:00</dt>").is_empty());
     assert!(!validate(schema, "<dt>2024-01-01T12:00:0é0+000</dt>").is_empty());
+}
+
+#[test]
+fn xsd_datetime_facet_comparison_fails_closed_on_invalid_bounds() {
+    // Facet values (minInclusive/maxInclusive) are stored as raw strings and are
+    // not otherwise range-checked. A lexically-parseable but out-of-range bound
+    // (month 99, hour 99) must not yield a comparable ordering that silently
+    // accepts an instance value; the comparison must fail closed.
+    let dt_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dt">
+    <xs:simpleType>
+      <xs:restriction base="xs:dateTime">
+        <xs:maxInclusive value="2024-99-01T99:00:00Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        !validate(dt_schema, "<dt>2024-06-01T12:00:00Z</dt>").is_empty(),
+        "invalid dateTime facet bound must fail closed"
+    );
+
+    let time_schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="t">
+    <xs:simpleType>
+      <xs:restriction base="xs:time">
+        <xs:maxInclusive value="99:99:99Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    assert!(
+        !validate(time_schema, "<t>12:00:00Z</t>").is_empty(),
+        "invalid time facet bound must fail closed"
+    );
 }
 
 #[test]
@@ -860,5 +905,347 @@ fn xsd_complex_type_derivation_cycles_are_rejected() {
     assert!(
         errors.iter().any(|e| e.contains("derivation cycle")),
         "expected derivation cycle error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_datetime_facets_compare_actual_instants() {
+    // Date/time facets must compare temporal values, not lexical strings.
+    // This value sorts after the minimum as text but is two hours earlier in UTC.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="stamp">
+    <xs:simpleType>
+      <xs:restriction base="xs:dateTime">
+        <xs:minInclusive value="2024-01-01T00:00:00Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+
+    let invalid = validate(schema, "<stamp>2024-01-01T00:00:00+02:00</stamp>");
+    assert!(
+        invalid.iter().any(|e| e.contains("minInclusive")),
+        "expected instant-aware minInclusive error, got {invalid:?}"
+    );
+
+    assert!(validate(schema, "<stamp>2024-01-01T02:00:00+02:00</stamp>").is_empty());
+
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="stamp">
+    <xs:simpleType>
+      <xs:restriction base="xs:dateTime">
+        <xs:minInclusive value="2024-01-01T00:00:00.0002Z"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+    let invalid = validate(schema, "<stamp>2024-01-01T00:00:00.0001Z</stamp>");
+    assert!(
+        invalid.iter().any(|e| e.contains("minInclusive")),
+        "expected fractional instant comparison error, got {invalid:?}"
+    );
+}
+
+#[test]
+fn xsd_string_enumeration_is_not_datetime_normalized() {
+    // Enumeration comparison must only normalize temporal datatypes. Treating
+    // every dotted string as a timestamp lets values bypass string allow-lists.
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="role">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="admin"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+
+    assert!(validate(schema, "<role>admin</role>").is_empty());
+    let errors = validate(schema, "<role>admin.000</role>");
+    assert!(
+        errors.iter().any(|e| e.contains("allowed values")),
+        "expected string enumeration rejection, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_negative_date_rejects_extra_suffix() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="d" type="xs:date"/>
+</xs:schema>"#;
+
+    assert!(validate(schema, "<d>-2024-02-29</d>").is_empty());
+    let errors = validate(schema, "<d>-2024-02-29-extra</d>");
+    assert!(
+        errors.iter().any(|e| e.contains("date")),
+        "expected malformed negative date rejection, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_unresolved_element_ref_fails_closed() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           xmlns:i="urn:i"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:import namespace="urn:i"/>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="i:child"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+
+    let errors = validate(
+        schema,
+        r#"<t:root xmlns:t="urn:t" xmlns:i="urn:i"><i:child><x/></i:child></t:root>"#,
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("Element reference")),
+        "expected unresolved element reference error, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_attribute_refs_match_expanded_names() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+  <xs:attribute name="role" type="xs:int"/>
+  <xs:element name="user">
+    <xs:complexType>
+      <xs:attribute ref="t:role" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"#;
+
+    assert!(validate(schema, r#"<t:user xmlns:t="urn:t" t:role="123"/>"#).is_empty());
+    let errors = validate(schema, r#"<t:user xmlns:t="urn:t" role="123"/>"#);
+    assert!(
+        errors.iter().any(|e| e.contains("Required attribute")),
+        "expected required namespaced attribute rejection, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_strict_any_attribute_uses_actual_attribute_namespace() {
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:t="urn:t"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:attribute name="role" type="xs:int"/>
+  <xs:element name="user">
+    <xs:complexType>
+      <xs:anyAttribute namespace="##any" processContents="strict"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"###;
+
+    assert!(validate(schema, r#"<t:user xmlns:t="urn:t" t:role="123"/>"#).is_empty());
+    let errors = validate(
+        schema,
+        r#"<t:user xmlns:t="urn:t" xmlns:f="urn:f" f:role="abc"/>"#,
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("no global declaration")),
+        "expected exact namespace lookup for strict anyAttribute, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_pattern_compile_errors_fail_closed() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="code">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:pattern value="["/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>"#;
+
+    let errors = validate(schema, "<code>anything</code>");
+    assert!(
+        errors.iter().any(|e| e.contains("could not be compiled")),
+        "expected invalid pattern to reject validation, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_unique_fields_must_select_at_most_one_node() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="code" type="xs:string" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="item_code">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="code"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>"#;
+
+    let errors = validate(
+        schema,
+        "<root><item><code>A</code><code>B</code></item></root>",
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("must select at most one")),
+        "expected multi-field xs:unique rejection, got {errors:?}"
+    );
+}
+
+#[test]
+fn xsd_keyref_fields_must_select_at_most_one_node() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="code" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="code" type="xs:string" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="item_code">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="code"/>
+    </xs:key>
+    <xs:keyref name="ref_code" refer="item_code">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="code"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>"#;
+
+    let errors = validate(
+        schema,
+        "<root><item><code>A</code></item><ref><code>A</code><code>B</code></ref></root>",
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("must select at most one")),
+        "expected multi-field xs:keyref rejection, got {errors:?}"
+    );
+}
+
+#[test]
+fn dtd_content_model_depth_uses_parser_limit() {
+    let content_model = format!("{}a{}", "(".repeat(10), ")".repeat(10));
+    let xml = format!("<!DOCTYPE r [<!ELEMENT r {content_model}><!ELEMENT a EMPTY>]><r><a/></r>");
+    let err = Parser::new()
+        .with_max_depth(5)
+        .parse(&xml)
+        .expect_err("DTD content model nesting must honor parser depth limit");
+    assert!(
+        err.to_string().contains("DTD content model depth limit"),
+        "expected DTD depth error, got {err:?}"
+    );
+}
+
+#[test]
+fn xslt_comment_constructor_rejects_markup_breakout() {
+    let xslt = r#"<xsl:stylesheet version="1.0"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+  <xsl:template match="/">
+    <xsl:comment><xsl:value-of select="/r"/></xsl:comment>
+  </xsl:template>
+</xsl:stylesheet>"#;
+
+    assert_eq!(
+        uppsala::transform(xslt, "<r>safe</r>").unwrap(),
+        "<!--safe-->"
+    );
+    let err = uppsala::transform(xslt, "<r>--&gt;&lt;evil/&gt;</r>")
+        .expect_err("comment breakout text must be rejected");
+    assert!(
+        err.to_string().contains("xsl:comment content"),
+        "expected xsl:comment hardening error, got {err:?}"
+    );
+}
+
+#[test]
+fn xslt_processing_instruction_rejects_markup_breakout() {
+    let xslt = r#"<xsl:stylesheet version="1.0"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+  <xsl:template match="/">
+    <xsl:processing-instruction name="ok"><xsl:value-of select="/r"/></xsl:processing-instruction>
+  </xsl:template>
+</xsl:stylesheet>"#;
+
+    assert_eq!(
+        uppsala::transform(xslt, "<r>safe</r>").unwrap(),
+        "<?ok safe?>"
+    );
+    let err = uppsala::transform(xslt, "<r>?&gt;&lt;evil/&gt;</r>")
+        .expect_err("processing-instruction breakout text must be rejected");
+    assert!(
+        err.to_string().contains("xsl:processing-instruction data"),
+        "expected xsl:processing-instruction hardening error, got {err:?}"
+    );
+}
+
+#[test]
+fn exslt_padding_has_output_cap() {
+    let xslt = r#"<xsl:stylesheet version="1.0"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+           xmlns:str="http://exslt.org/strings">
+  <xsl:output method="text"/>
+  <xsl:template match="/">
+    <xsl:value-of select="str:padding(4, '*')"/>
+  </xsl:template>
+</xsl:stylesheet>"#;
+    assert_eq!(transform_exslt(xslt, "<r/>").unwrap(), "****");
+
+    let xslt = r#"<xsl:stylesheet version="1.0"
+           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+           xmlns:str="http://exslt.org/strings">
+  <xsl:output method="text"/>
+  <xsl:template match="/">
+    <xsl:value-of select="str:padding(1000001, 'x')"/>
+  </xsl:template>
+</xsl:stylesheet>"#;
+    let err = transform_exslt(xslt, "<r/>").expect_err("oversized padding must fail");
+    assert!(
+        err.to_string().contains("str:padding length"),
+        "expected EXSLT padding cap error, got {err:?}"
+    );
+}
+
+#[test]
+fn xsd_qname_rejects_unbound_prefix() {
+    let schema = r#"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="q" type="xs:QName"/>
+</xs:schema>"#;
+
+    assert!(validate(schema, r#"<q xmlns:ok="urn:ok">ok:name</q>"#).is_empty());
+    let errors = validate(schema, "<q>missing:name</q>");
+    assert!(
+        errors.iter().any(|e| e.contains("prefix 'missing'")),
+        "expected unbound QName prefix rejection, got {errors:?}"
     );
 }

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -945,6 +945,30 @@ fn xsd_attribute_form_qualified_overrides_unqualified_default() {
 }
 
 #[test]
+fn xsd_unknown_attribute_form_falls_back_to_schema_default() {
+    // An unrecognized form= value must not silently force the attribute to be
+    // unqualified; like parse_element_decl, it falls back to the schema's
+    // attributeFormDefault.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified"
+           attributeFormDefault="qualified">
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:string" use="required" form="bogus"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"###;
+
+    let qualified = r#"<t:r xmlns:t="urn:t" t:id="ok"/>"#;
+    let errors = validate(schema, qualified);
+    assert!(
+        errors.is_empty(),
+        "unknown form must fall back to attributeFormDefault, got {errors:?}"
+    );
+}
+
+#[test]
 fn xsd_complex_type_derivation_cycles_are_rejected() {
     // Recursive complex-type derivation can otherwise loop while resolving the
     // effective content model. The validator should detect the cycle and report

--- a/tests/security_regressions.rs
+++ b/tests/security_regressions.rs
@@ -884,6 +884,67 @@ fn xsd_attribute_wildcard_union_other_plus_local_excludes_target() {
 }
 
 #[test]
+fn xsd_attribute_form_default_qualified_matches_target_namespace() {
+    // attributeFormDefault="qualified" puts local attribute uses in the schema
+    // target namespace; namespace-aware attribute matching must accept the
+    // prefixed instance attribute and reject the unqualified spelling.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified"
+           attributeFormDefault="qualified">
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"###;
+
+    let qualified = r#"<t:r xmlns:t="urn:t" t:id="ok"/>"#;
+    let errors = validate(schema, qualified);
+    assert!(
+        errors.is_empty(),
+        "qualified local attribute must satisfy its declaration, got {errors:?}"
+    );
+
+    let unqualified = r#"<t:r xmlns:t="urn:t" id="no"/>"#;
+    let errors = validate(schema, unqualified);
+    assert!(
+        !errors.is_empty(),
+        "unqualified attribute must not satisfy a qualified declaration"
+    );
+}
+
+#[test]
+fn xsd_attribute_form_qualified_overrides_unqualified_default() {
+    // form="qualified" on a single attribute use qualifies just that attribute
+    // while sibling declarations stay in no namespace.
+    let schema = r###"<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:t"
+           elementFormDefault="qualified">
+  <xs:element name="r">
+    <xs:complexType>
+      <xs:attribute name="q" type="xs:string" use="required" form="qualified"/>
+      <xs:attribute name="u" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"###;
+
+    let valid = r#"<t:r xmlns:t="urn:t" t:q="ok" u="ok"/>"#;
+    let errors = validate(schema, valid);
+    assert!(
+        errors.is_empty(),
+        "form=qualified attribute must match target namespace, got {errors:?}"
+    );
+
+    let invalid = r#"<t:r xmlns:t="urn:t" q="no" u="ok"/>"#;
+    let errors = validate(schema, invalid);
+    assert!(
+        !errors.is_empty(),
+        "unqualified spelling must not satisfy a form=qualified declaration"
+    );
+}
+
+#[test]
 fn xsd_complex_type_derivation_cycles_are_rejected() {
     // Recursive complex-type derivation can otherwise loop while resolving the
     // effective content model. The validator should detect the cycle and report


### PR DESCRIPTION
Fix XSD fail-open cases for unresolved refs, attribute namespace matching, strict wildcards, invalid facets, QName prefixes, and identity fields. Apply parser depth limits to DTD content models, reject unsafe XSLT comment/PI output, cap EXSLT padding, and add 0.7.1 security regression coverage plus ADR/changelog.