### PR TITLE
feat: optimize XML parsing and add libxml2 benchmark workflow

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,115 +1,163 @@
 # Performance
 
-Uppsala uses accelerated byte scanning for text content and attribute values:
-SSE2 SIMD on x86_64 (16 bytes per iteration) and a one-pass scalar delimiter
-scanner elsewhere. Parsing throughput depends heavily on document shape: long
-plain-text spans and large attribute values are favorable, while very small
-documents are dominated by fixed parser overhead.
+Uppsala uses accelerated byte scanning for parser hot loops:
 
-## Results
+- SSE2 delimiter scanning on x86_64 for text content and attribute values.
+- SSE2 ASCII XML-name continuation scanning for element and attribute names.
+- SSE2 single-byte search for reference parsing.
+- Scalar reference implementations on non-x86_64 and for SIMD tail bytes.
 
-The tables below compare release builds (`cargo run --release`, no extra
-profile overrides) of Uppsala 0.5.2 against a local checkout of roxmltree
-0.21.1. Results are median parse times from 101 samples on x86_64 (the SSE2
-scanner path). The `Ratio` column is
-`roxmltree / Uppsala`; values above 1.0 mean Uppsala parsed faster.
+Parsing throughput depends heavily on document shape. Long plain-text spans,
+large attribute values, and ASCII-heavy names favor the bulk scanners. Very
+small documents are dominated by fixed parser and allocation overhead.
 
-### roxmltree benchmark inputs
+## Current libxml2 comparison
 
-| File | Size | Uppsala | roxmltree | Ratio |
-|------|------|---------|-----------|-------|
-| fonts.conf | 429 B | 2.9 us | 4.0 us | 1.38x |
-| medium.svg | 155 KB | 306 us | 489 us | 1.60x |
-| large.plist | 321 KB | 1.72 ms | 2.39 ms | 1.39x |
-| huge.xml | 835 KB | 3.69 ms | 4.80 ms | 1.30x |
-| gigantic.svg | 1.34 MB | 411 us | 1.94 ms | 4.73x |
-| cdata.xml | 102 KB | 215 us | 252 us | 1.17x |
-| text.xml | 129 KB | 650 us | 5.96 ms | 9.17x |
-| attributes.xml | 271 KB | 1.48 ms | 5.24 ms | 3.55x |
+The tables below compare a native x86_64 server build of Uppsala against a
+local sibling checkout of libxml2, called directly through `xmlReadMemory`.
+The harness reports median parse time from in-memory strings; file I/O and
+process startup are not included.
 
-### SAML-shaped inputs
+Build setup used for these numbers (`just bench-libxml2 101`):
 
-The main production target is SAML: namespace-heavy documents in the 3-30 KB
-range with signed assertions. On generated SAML-shaped inputs, default
-namespace-aware parsing is consistently faster than roxmltree.
+- Uppsala: `RUSTFLAGS='-C target-cpu=native' cargo build --release`
+- libxml2: static release library from `../libxml2`, built with
+  `-O3 -DNDEBUG -fno-semantic-interposition -march=native`
+- CPU pinning: `taskset -c 0`
 
-| File | Size | Uppsala | roxmltree | Ratio |
-|------|------|---------|-----------|-------|
-| SAML small | 3.5 KB | 7.7 us | 13.3 us | 1.74x |
-| SAML medium | 9.1 KB | 25.1 us | 29.0 us | 1.16x |
-| SAML large | 27.8 KB | 62.7 us | 92.1 us | 1.47x |
+The `Ratio` column is `libxml2 / Uppsala`; values above `1.0` mean Uppsala
+parsed faster.
 
-Disabling namespace resolution improves some ordinary XML inputs further, but
-SAML users should usually keep namespace-aware parsing enabled.
+### Full libxml2 report
 
-## Running the performance test
+The report includes SAML-shaped request/response documents, larger generated
+real-life-shaped XML documents, one local pyFF metadata fixture, and two larger
+fixtures from the libxml2 checkout.
+
+| Input | Size | Uppsala ns | Uppsala no-ns | libxml2 | Ratio ns | Ratio no-ns |
+|---|---:|---:|---:|---:|---:|---:|
+| SAML small | 3.4 KB | 9.494 us | 6.053 us | 23.435 us | 2.47x | 3.87x |
+| SAML medium | 8.9 KB | 16.169 us | 19.331 us | 75.494 us | 4.67x | 3.91x |
+| SAML large | 27.2 KB | 64.384 us | 39.515 us | 161.087 us | 2.50x | 4.08x |
+| SAML metadata aggregate | 666.3 KB | 2.000 ms | 1.794 ms | 4.506 ms | 2.25x | 2.51x |
+| Atom feed archive | 848.2 KB | 3.573 ms | 3.342 ms | 6.310 ms | 1.77x | 1.89x |
+| SOAP invoice batch | 715.2 KB | 3.568 ms | 3.350 ms | 5.753 ms | 1.61x | 1.72x |
+| pyFF sample metadata | 3.5 KB | 12.178 us | 10.712 us | 37.922 us | 3.11x | 3.54x |
+| libxml2 `nvdcve_0.xml` | 287.4 KB | 1.442 ms | 1.385 ms | 2.571 ms | 1.78x | 1.86x |
+| libxml2 `comps_0.xml` | 607.9 KB | 2.990 ms | 2.996 ms | 5.658 ms | 1.89x | 1.89x |
+
+These are local measurements, not a universal claim. Re-run the harness on the
+target server class before making capacity decisions.
+
+## Running the performance harness
 
 The comparison harness is checked into the repo under `performance-harness/`.
 It is kept outside the main crate's targets so normal library builds and tests
-do not depend on roxmltree.
+do not depend on libxml2.
 
-### Prerequisites
+### One-command libxml2 benchmark
 
-The harness expects a sibling checkout of roxmltree next to the Uppsala repo:
+With libxml2 checked out at the default `../libxml2` location, run:
+
+```bash
+just bench-libxml2
+```
+
+This configures/builds libxml2 as a local static release library, builds the
+Uppsala harness with `RUSTFLAGS='-C target-cpu=native'`, pins the run to CPU 0
+when `taskset` is available, and prints one final Markdown table containing
+the SAML-shaped inputs, larger generated XML shapes, and representative
+local/libxml2 XML fixtures.
+
+The default sample count is `301`. Use a larger count for steadier medians:
+
+```bash
+just bench-libxml2 1001
+```
+
+To use a different libxml2 checkout:
+
+```bash
+LIBXML2_DIR=/path/to/libxml2 just bench-libxml2
+```
+
+### Manual setup
+
+By default, the harness expects a sibling libxml2 checkout next to the Uppsala
+repo:
 
 ```text
 code/
   uppsala/
     performance-harness/
-  roxmltree/
+  libxml2/
 ```
 
-Because Uppsala's hand-written SSE2 scanner only runs on x86_64, run the harness
-on an x86_64 machine to reproduce the SIMD numbers above. On aarch64 / Apple
-Silicon it exercises the scalar fallback instead.
-
-### Run roxmltree's benchmark inputs
+Build libxml2 locally:
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  suite ../roxmltree/benches 101
+cmake -S ../libxml2 -B ../libxml2/build-uppsala-release -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DLIBXML2_WITH_PROGRAMS=OFF \
+  -DLIBXML2_WITH_TESTS=OFF \
+  -DLIBXML2_WITH_ZLIB=OFF \
+  -DLIBXML2_WITH_ICONV=OFF \
+  -DLIBXML2_WITH_ICU=OFF \
+  -DLIBXML2_WITH_MODULES=OFF \
+  -DLIBXML2_WITH_PYTHON=OFF \
+  -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -fno-semantic-interposition -march=native'
+cmake --build ../libxml2/build-uppsala-release
 ```
 
-### Run the SAML-shaped inputs
+The harness build script links `$LIBXML2_DIR/build-uppsala-release/libxml2.a`,
+defaulting `LIBXML2_DIR` to `../libxml2`. Override the source checkout with
+`LIBXML2_DIR=/path/to/libxml2`; override only the build-output directory with
+`LIBXML2_LIB_DIR=/path/to/build` if needed.
+
+### Run SAML-shaped inputs manually
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  saml 101
+RUSTFLAGS='-C target-cpu=native' cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- saml 1001
 ```
 
-### Run a single file
+### Run a single file manually
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  file ../roxmltree/benches/large.plist 101
+RUSTFLAGS='-C target-cpu=native' cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- \
+  file test-data/pyff-xslt/sample-metadata.xml 1001
 ```
 
 The trailing number is the sample count (default `31`). Each run does a short
-warmup, then reports medians in microseconds. Output is tab-separated with
-columns for both namespace-aware and namespace-disabled Uppsala timings:
+warmup, then reports medians in microseconds. Output is tab-separated:
 
 ```text
-file  bytes  uppsala_ns_us  uppsala_no_ns_us  roxmltree_us  ratio_ns  ratio_no_ns
+file  bytes  uppsala_ns_us  uppsala_no_ns_us  libxml2_us  ratio_ns  ratio_no_ns
 ```
 
-The `ratio_ns` column corresponds to the default namespace-aware mode used in
-the tables above; `ratio_no_ns` is Uppsala with namespace resolution disabled.
+The `ratio_ns` column corresponds to the default namespace-aware mode; SAML
+users should usually care about this column. `ratio_no_ns` is Uppsala with
+namespace resolution disabled.
 
-See [`performance-harness/README.md`](../performance-harness/README.md) for
-additional notes.
-
-## Profiling with `perf`
+## Profiling
 
 To find hot functions when optimizing the parser, build the harness and record
-a profile (Linux, `perf` installed):
+a profile on Linux:
 
 ```bash
-cargo build --release --manifest-path performance-harness/Cargo.toml
-perf record -g --call-graph dwarf \
-  ./target/release/uppsala-performance-harness suite ../roxmltree/benches 101
-perf report --no-children --sort=dso,symbol
+RUSTFLAGS='-C target-cpu=native' cargo build --release \
+  --manifest-path performance-harness/Cargo.toml
+sudo perf record -g --call-graph dwarf \
+  performance-harness/target/release/uppsala-performance-harness saml 1001
+sudo perf report --no-children --sort=dso,symbol
 ```
 
-Focus on self-time (`--no-children`) to identify the real bottleneck rather than
-its callers, and use `perf annotate --symbol=<fn>` to drill into a hot loop's
+Focus on self-time (`--no-children`) to identify the real bottleneck rather
+than its callers, and use `perf annotate --symbol=<fn>` to inspect a hot loop's
 per-instruction sample counts.
+
+On this container, hardware counters such as `branch-misses` and `cycles` were
+reported as unsupported even under `sudo perf stat`; use a host with PMU access
+for branch-prediction measurements.

--- a/justfile
+++ b/justfile
@@ -79,12 +79,50 @@ build:
 build-perf:
     cargo build --release --manifest-path performance-harness/Cargo.toml
 
+# Build libxml2 + native harness, then print the full libxml2 comparison table
+bench-libxml2 samples="301":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    libxml2_dir="${LIBXML2_DIR:-../libxml2}"
+    if [[ ! -d "$libxml2_dir" ]]; then
+        echo "missing libxml2 checkout at $libxml2_dir" >&2
+        echo "set LIBXML2_DIR=/path/to/libxml2 to use a different checkout" >&2
+        exit 1
+    fi
+    libxml2_dir="$(cd "$libxml2_dir" && pwd)"
+    libxml2_build="${LIBXML2_LIB_DIR:-$libxml2_dir/build-uppsala-release}"
+    case "$libxml2_build" in
+      /*) ;;
+      *) libxml2_build="$(pwd)/$libxml2_build" ;;
+    esac
+    export LIBXML2_DIR="$libxml2_dir"
+    export LIBXML2_LIB_DIR="$libxml2_build"
+    cmake -S "$libxml2_dir" -B "$libxml2_build" -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DLIBXML2_WITH_PROGRAMS=OFF \
+      -DLIBXML2_WITH_TESTS=OFF \
+      -DLIBXML2_WITH_ZLIB=OFF \
+      -DLIBXML2_WITH_ICONV=OFF \
+      -DLIBXML2_WITH_ICU=OFF \
+      -DLIBXML2_WITH_MODULES=OFF \
+      -DLIBXML2_WITH_PYTHON=OFF \
+      -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -fno-semantic-interposition -march=native' >&2
+    cmake --build "$libxml2_build" >&2
+    RUSTFLAGS='-C target-cpu=native' CARGO_TARGET_DIR=target/perf-native \
+      cargo build --release --manifest-path performance-harness/Cargo.toml >&2
+    if command -v taskset >/dev/null 2>&1; then
+        taskset -c 0 target/perf-native/release/uppsala-performance-harness libxml2-report {{samples}}
+    else
+        target/perf-native/release/uppsala-performance-harness libxml2-report {{samples}}
+    fi
+
 # Run generated SAML-shaped parser comparison inputs
 perf-saml samples="101":
     cargo run --release --manifest-path performance-harness/Cargo.toml -- saml {{samples}}
 
-# Run roxmltree's benchmark input suite; expects ../roxmltree by default
-perf-suite dir="../roxmltree/benches" samples="101":
+# Run the fixed benchmark input suite from a directory
+perf-suite dir samples="101":
     cargo run --release --manifest-path performance-harness/Cargo.toml -- suite {{dir}} {{samples}}
 
 # Run one XML file through the performance comparison harness

--- a/performance-harness/Cargo.toml
+++ b/performance-harness/Cargo.toml
@@ -3,7 +3,7 @@ name = "uppsala-performance-harness"
 version = "0.1.0"
 edition = "2021"
 publish = false
+build = "build.rs"
 
 [dependencies]
 uppsala = { path = ".." }
-roxmltree = { path = "../../roxmltree" }

--- a/performance-harness/README.md
+++ b/performance-harness/README.md
@@ -1,58 +1,79 @@
 # Uppsala Performance Harness
 
 This is a local comparison harness for Uppsala's XML parser against a sibling
-checkout of `roxmltree`.
+checkout of `libxml2`.
 
-It is intentionally checked into the repo so the same commands can be run later
-on an x86_64 machine. That matters because Uppsala's hand-written SSE2 scanner
-only runs on x86_64; Apple Silicon and other non-x86_64 targets use the scalar
-fallback.
+The harness measures parse-only time from in-memory strings. It calls libxml2
+directly through `xmlReadMemory` and frees each parsed `xmlDoc`, so timings do
+not include `xmllint` process startup or file I/O.
 
-Expected layout:
+Default layout:
 
 ```text
 code/
   uppsala/
     performance-harness/
-  roxmltree/
+  libxml2/
 ```
 
-The harness measures parse-only time. It reports medians in microseconds after a
-small warmup. The `Ratio` column is `roxmltree / Uppsala`; values above `1.0`
-mean Uppsala parsed faster.
+Set `LIBXML2_DIR=/path/to/libxml2` to use a different checkout.
 
-## Run One File
+## Build libxml2
+
+Build a local release static library before running the harness. The default
+source checkout is `../libxml2`; substitute `$LIBXML2_DIR` when using a custom
+checkout:
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  file ../roxmltree/benches/large.plist 101
+cmake -S ../libxml2 -B ../libxml2/build-uppsala-release -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DLIBXML2_WITH_PROGRAMS=OFF \
+  -DLIBXML2_WITH_TESTS=OFF \
+  -DLIBXML2_WITH_ZLIB=OFF \
+  -DLIBXML2_WITH_ICONV=OFF \
+  -DLIBXML2_WITH_ICU=OFF \
+  -DLIBXML2_WITH_MODULES=OFF \
+  -DLIBXML2_WITH_PYTHON=OFF \
+  -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -fno-semantic-interposition -march=native'
+cmake --build ../libxml2/build-uppsala-release
 ```
 
-The final argument is the sample count. If omitted, it defaults to `31`.
-
-## Run roxmltree's Benchmark Inputs
+The harness build script looks for
+`${LIBXML2_DIR:-../libxml2}/build-uppsala-release/libxml2.a` by default. To use
+another build directory:
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  suite ../roxmltree/benches 101
+LIBXML2_LIB_DIR=/path/to/libxml2/build cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- saml 101
 ```
 
-This runs:
+## One-Command Report
 
-- `fonts.conf`
-- `medium.svg`
-- `large.plist`
-- `huge.xml`
-- `gigantic.svg`
-- `cdata.xml`
-- `text.xml`
-- `attributes.xml`
+From the repository root:
+
+```bash
+just bench-libxml2
+```
+
+This builds libxml2 and the native Uppsala harness, then prints one final table
+with:
+
+- SAML-shaped response documents
+- a larger generated SAML metadata aggregate
+- a larger generated Atom feed archive
+- a larger generated SOAP invoice batch
+- a local pyFF metadata fixture
+- larger XML fixtures from the libxml2 checkout
+
+Use `LIBXML2_DIR=/path/to/libxml2 just bench-libxml2` for a non-default
+checkout.
 
 ## Run SAML-Shaped Inputs
 
 ```bash
-cargo run --release --manifest-path performance-harness/Cargo.toml -- \
-  saml 101
+RUSTFLAGS='-C target-cpu=native' cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- saml 101
 ```
 
 This generates three namespace-heavy SAML-like responses in memory:
@@ -64,12 +85,48 @@ This generates three namespace-heavy SAML-like responses in memory:
 These are synthetic parser fixtures, not security or interoperability test
 vectors.
 
-## Notes
+## Run One File
 
-- Uppsala is benchmarked twice: namespace-aware default mode and
-  namespace-disabled mode.
-- SAML users should usually care about the namespace-aware column.
-- On x86_64, this harness exercises Uppsala's SSE2 delimiter scanner. On
-  aarch64/Apple Silicon, it exercises the scalar fallback.
-- The harness intentionally lives outside the main crate's `[[bench]]` targets
-  so normal library builds and tests do not depend on `roxmltree`.
+```bash
+RUSTFLAGS='-C target-cpu=native' cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- \
+  file test-data/pyff-xslt/sample-metadata.xml 101
+```
+
+The final argument is the sample count. If omitted, it defaults to `31`.
+
+## Run A Fixed File Suite
+
+```bash
+RUSTFLAGS='-C target-cpu=native' cargo run --release \
+  --manifest-path performance-harness/Cargo.toml -- \
+  suite /path/to/benchmark-files 101
+```
+
+The suite directory must contain:
+
+- `fonts.conf`
+- `medium.svg`
+- `large.plist`
+- `huge.xml`
+- `gigantic.svg`
+- `cdata.xml`
+- `text.xml`
+- `attributes.xml`
+
+## Output
+
+Output is tab-separated:
+
+```text
+file  bytes  uppsala_ns_us  uppsala_no_ns_us  libxml2_us  ratio_ns  ratio_no_ns
+```
+
+The `Ratio` columns are `libxml2 / Uppsala`; values above `1.0` mean Uppsala
+parsed faster. Uppsala is benchmarked twice: namespace-aware default mode and
+namespace-disabled mode. SAML users should usually care about the
+namespace-aware column.
+
+On x86_64, this harness exercises Uppsala's SSE2 scanners. For server
+deployment benchmarking, prefer `RUSTFLAGS='-C target-cpu=native'` so LLVM can
+use the host CPU's scheduling model and baseline extensions where applicable.

--- a/performance-harness/build.rs
+++ b/performance-harness/build.rs
@@ -31,8 +31,13 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=LIBXML2_DIR");
     println!("cargo:rerun-if-env-changed=LIBXML2_LIB_DIR");
-    println!("cargo:rerun-if-changed={}", lib_dir.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        lib_dir.join("libxml2.a").display()
+    );
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-lib=static=xml2");
-    println!("cargo:rustc-link-lib=m");
+    if env::var_os("CARGO_CFG_UNIX").is_some() {
+        println!("cargo:rustc-link-lib=m");
+    }
 }

--- a/performance-harness/build.rs
+++ b/performance-harness/build.rs
@@ -1,0 +1,38 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let repo_dir = manifest_dir.parent().expect("harness lives under repo root");
+    let default_src_dir = repo_dir.join("../libxml2");
+    let src_dir = env::var_os("LIBXML2_DIR")
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                repo_dir.join(path)
+            }
+        })
+        .unwrap_or(default_src_dir);
+    let default_lib_dir = src_dir
+        .join("build-uppsala-release")
+        .canonicalize()
+        .unwrap_or_else(|_| src_dir.join("build-uppsala-release"));
+    let lib_dir = env::var_os("LIBXML2_LIB_DIR")
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                repo_dir.join(path)
+            }
+        })
+        .unwrap_or(default_lib_dir);
+
+    println!("cargo:rerun-if-env-changed=LIBXML2_DIR");
+    println!("cargo:rerun-if-env-changed=LIBXML2_LIB_DIR");
+    println!("cargo:rerun-if-changed={}", lib_dir.display());
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=xml2");
+    println!("cargo:rustc-link-lib=m");
+}

--- a/performance-harness/src/main.rs
+++ b/performance-harness/src/main.rs
@@ -1,19 +1,63 @@
 use std::{
     env, fs,
     hint::black_box,
+    os::raw::{c_char, c_int},
     path::{Path, PathBuf},
+    ptr,
+    sync::Once,
     time::{Duration, Instant},
 };
 
 const DEFAULT_SAMPLES: usize = 31;
 const WARMUPS: usize = 5;
+const XML_PARSE_NONET: c_int = 1 << 11;
+const XML_PARSE_COMPACT: c_int = 1 << 16;
+const LIBXML2_PARSE_OPTIONS: c_int = XML_PARSE_NONET | XML_PARSE_COMPACT;
+
+#[repr(C)]
+struct XmlDoc {
+    _private: [u8; 0],
+}
+
+type XmlDocPtr = *mut XmlDoc;
+
+extern "C" {
+    fn xmlInitParser();
+    fn xmlCleanupParser();
+    fn xmlReadMemory(
+        buffer: *const c_char,
+        size: c_int,
+        url: *const c_char,
+        encoding: *const c_char,
+        options: c_int,
+    ) -> XmlDocPtr;
+    fn xmlFreeDoc(cur: XmlDocPtr);
+}
+
+static LIBXML2_INIT: Once = Once::new();
+
+fn init_libxml2() {
+    LIBXML2_INIT.call_once(|| unsafe {
+        xmlInitParser();
+    });
+}
+
+struct Libxml2Cleanup;
+
+impl Drop for Libxml2Cleanup {
+    fn drop(&mut self) {
+        unsafe {
+            xmlCleanupParser();
+        }
+    }
+}
 
 struct Row {
     name: String,
     bytes: usize,
     uppsala_ns: Duration,
     uppsala_no_ns: Duration,
-    roxmltree: Duration,
+    libxml2: Duration,
 }
 
 fn bench_one<F, T>(mut f: F, samples: usize) -> Vec<Duration>
@@ -44,51 +88,77 @@ fn bench_text(name: impl Into<String>, text: &str, samples: usize) -> Row {
 
     let mut uppsala_ns = bench_one(|| parser_ns.parse(text).unwrap(), samples);
     let mut uppsala_no_ns = bench_one(|| parser_no_ns.parse(text).unwrap(), samples);
-    let mut roxmltree = bench_one(
-        || {
-            roxmltree::Document::parse_with_options(
-                text,
-                roxmltree::ParsingOptions {
-                    allow_dtd: true,
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-        },
-        samples,
-    );
+    let mut libxml2 = bench_one(|| parse_libxml2(text), samples);
 
     Row {
         name: name.into(),
         bytes: text.len(),
         uppsala_ns: median(&mut uppsala_ns),
         uppsala_no_ns: median(&mut uppsala_no_ns),
-        roxmltree: median(&mut roxmltree),
+        libxml2: median(&mut libxml2),
     }
 }
 
 fn print_header() {
-    println!("file\tbytes\tuppsala_ns_us\tuppsala_no_ns_us\troxmltree_us\tratio_ns\tratio_no_ns");
+    println!("file\tbytes\tuppsala_ns_us\tuppsala_no_ns_us\tlibxml2_us\tratio_ns\tratio_no_ns");
 }
 
 fn print_row(row: &Row) {
     let u_ns = micros(row.uppsala_ns);
     let u_no_ns = micros(row.uppsala_no_ns);
-    let r = micros(row.roxmltree);
+    let l = micros(row.libxml2);
     println!(
         "{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
         row.name,
         row.bytes,
         u_ns,
         u_no_ns,
-        r,
-        row.roxmltree.as_secs_f64() / row.uppsala_ns.as_secs_f64(),
-        row.roxmltree.as_secs_f64() / row.uppsala_no_ns.as_secs_f64()
+        l,
+        row.libxml2.as_secs_f64() / row.uppsala_ns.as_secs_f64(),
+        row.libxml2.as_secs_f64() / row.uppsala_no_ns.as_secs_f64()
     );
 }
 
 fn micros(duration: Duration) -> f64 {
     duration.as_nanos() as f64 / 1000.0
+}
+
+fn format_duration(duration: Duration) -> String {
+    let us = micros(duration);
+    if us >= 1000.0 {
+        format!("{:.3} ms", us / 1000.0)
+    } else {
+        format!("{us:.3} us")
+    }
+}
+
+fn format_size(bytes: usize) -> String {
+    if bytes >= 1024 * 1024 {
+        format!("{:.2} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else if bytes >= 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn parse_libxml2(text: &str) {
+    init_libxml2();
+    let size: c_int = text.len().try_into().expect("input too large for libxml2");
+    let doc = unsafe {
+        xmlReadMemory(
+            text.as_ptr() as *const c_char,
+            size,
+            ptr::null(),
+            ptr::null(),
+            LIBXML2_PARSE_OPTIONS,
+        )
+    };
+    assert!(!doc.is_null(), "libxml2 parse failed");
+    black_box(doc);
+    unsafe {
+        xmlFreeDoc(doc);
+    }
 }
 
 fn run_file(path: &Path, samples: usize) {
@@ -127,6 +197,73 @@ fn run_saml(samples: usize) {
     print_header();
     for (name, text) in cases {
         print_row(&bench_text(name, &text, samples));
+    }
+}
+
+fn run_libxml2_report(samples: usize) {
+    let mut rows = Vec::new();
+    let libxml2_dir = env::var_os("LIBXML2_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("../libxml2"));
+
+    let saml_cases = [
+        ("SAML small".to_string(), saml_fixture(3, 1, 8)),
+        ("SAML medium".to_string(), saml_fixture(16, 2, 32)),
+        ("SAML large".to_string(), saml_fixture(64, 4, 96)),
+    ];
+    for (name, text) in saml_cases {
+        rows.push(bench_text(name, &text, samples));
+    }
+
+    let generated_cases = [
+        (
+            "SAML metadata aggregate".to_string(),
+            saml_metadata_fixture(600, 4),
+        ),
+        ("Atom feed archive".to_string(), atom_feed_fixture(1_500, 2)),
+        (
+            "SOAP invoice batch".to_string(),
+            soap_invoice_batch_fixture(350, 8),
+        ),
+    ];
+    for (name, text) in generated_cases {
+        rows.push(bench_text(name, &text, samples));
+    }
+
+    let file_cases = [
+        (
+            "pyFF sample metadata",
+            PathBuf::from("test-data/pyff-xslt/sample-metadata.xml"),
+        ),
+        (
+            "libxml2 nvdcve_0.xml",
+            libxml2_dir.join("test/schemas/nvdcve_0.xml"),
+        ),
+        (
+            "libxml2 comps_0.xml",
+            libxml2_dir.join("test/relaxng/comps_0.xml"),
+        ),
+    ];
+    for (name, path) in file_cases {
+        let text = fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!("failed to read benchmark fixture {}: {err}", path.display());
+        });
+        rows.push(bench_text(name, &text, samples));
+    }
+
+    println!("| Input | Size | Uppsala ns | Uppsala no-ns | libxml2 | Ratio ns | Ratio no-ns |");
+    println!("|---|---:|---:|---:|---:|---:|---:|");
+    for row in rows {
+        println!(
+            "| {} | {} | {} | {} | {} | {:.2}x | {:.2}x |",
+            row.name,
+            format_size(row.bytes),
+            format_duration(row.uppsala_ns),
+            format_duration(row.uppsala_no_ns),
+            format_duration(row.libxml2),
+            row.libxml2.as_secs_f64() / row.uppsala_ns.as_secs_f64(),
+            row.libxml2.as_secs_f64() / row.uppsala_no_ns.as_secs_f64(),
+        );
     }
 }
 
@@ -179,6 +316,76 @@ fn saml_fixture(attr_count: usize, statement_count: usize, cert_repeats: usize) 
     )
 }
 
+fn saml_metadata_fixture(entity_count: usize, cert_repeats: usize) -> String {
+    let cert = "MIIC8DCCAdigAwIBAgIJAO0123456789abcdef".repeat(cert_repeats);
+    let mut xml = String::with_capacity(entity_count * 1300);
+    xml.push_str(r#"<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="urn:example:federation">"#);
+    for i in 0..entity_count {
+        xml.push_str(&format!(
+            r#"<md:EntityDescriptor entityID="https://sp{i}.example.org/metadata">
+  <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>{cert}</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp{i}.example.org/saml/acs" index="{i}"/>
+    <md:AttributeConsumingService index="{i}"><md:ServiceName xml:lang="en">Example Service {i}</md:ServiceName><md:RequestedAttribute Name="urn:example:attribute:eduPersonPrincipalName" isRequired="true"/></md:AttributeConsumingService>
+  </md:SPSSODescriptor>
+  <md:Organization><md:OrganizationName xml:lang="en">Example Org {i}</md:OrganizationName><md:OrganizationURL xml:lang="en">https://sp{i}.example.org/</md:OrganizationURL></md:Organization>
+</md:EntityDescriptor>"#
+        ));
+    }
+    xml.push_str("</md:EntitiesDescriptor>");
+    xml
+}
+
+fn atom_feed_fixture(entry_count: usize, body_repeats: usize) -> String {
+    let body = "This release note describes parser behavior, deployment status, and operational metadata. ".repeat(body_repeats);
+    let mut xml = String::with_capacity(entry_count * (body.len() + 450));
+    xml.push_str(r#"<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="urn:example:app"><title>Operations Feed</title><id>urn:example:feed</id><updated>2026-07-04T12:00:00Z</updated>"#);
+    for i in 0..entry_count {
+        xml.push_str(&format!(
+            r#"<entry>
+  <title>Deployment event {i}</title>
+  <id>urn:example:event:{i}</id>
+  <updated>2026-07-04T12:{:02}:00Z</updated>
+  <author><name>Platform Team</name><email>platform@example.org</email></author>
+  <category term="deployment"/><category term="region-{}"/>
+  <link rel="alternate" href="https://status.example.org/events/{i}"/>
+  <app:severity>{}</app:severity>
+  <summary>{body}</summary>
+</entry>"#,
+            i % 60,
+            i % 8,
+            if i % 17 == 0 { "warning" } else { "info" }
+        ));
+    }
+    xml.push_str("</feed>");
+    xml
+}
+
+fn soap_invoice_batch_fixture(invoice_count: usize, lines_per_invoice: usize) -> String {
+    let mut xml = String::with_capacity(invoice_count * lines_per_invoice * 260);
+    xml.push_str(r#"<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:inv="urn:example:invoice" xmlns:xs="http://www.w3.org/2001/XMLSchema"><soap:Header><inv:Batch id="batch-2026-07-04" region="eu-north"/></soap:Header><soap:Body><inv:Invoices>"#);
+    for invoice in 0..invoice_count {
+        xml.push_str(&format!(
+            r#"<inv:Invoice id="INV-{invoice:06}" currency="EUR" issued="2026-07-04">
+  <inv:Customer id="CUST-{invoice:06}"><inv:Name>Example Customer {invoice}</inv:Name><inv:Country>SE</inv:Country></inv:Customer>
+  <inv:Lines>"#
+        ));
+        for line in 0..lines_per_invoice {
+            xml.push_str(&format!(
+                r#"<inv:Line number="{line}"><inv:Sku>SKU-{invoice:06}-{line:03}</inv:Sku><inv:Description>Managed service subscription tier {}</inv:Description><inv:Quantity>{}</inv:Quantity><inv:UnitPrice>{}.95</inv:UnitPrice><inv:TaxRate>25</inv:TaxRate></inv:Line>"#,
+                line % 5,
+                (line % 9) + 1,
+                10 + (invoice + line) % 90
+            ));
+        }
+        xml.push_str("</inv:Lines><inv:Total>");
+        xml.push_str(&(lines_per_invoice * 42).to_string());
+        xml.push_str(".00</inv:Total></inv:Invoice>");
+    }
+    xml.push_str("</inv:Invoices></soap:Body></soap:Envelope>");
+    xml
+}
+
 fn parse_samples(args: &[String], index: usize) -> usize {
     args.get(index)
         .and_then(|s| s.parse().ok())
@@ -189,13 +396,15 @@ fn usage() -> ! {
     eprintln!(
         "usage:
   uppsala-performance-harness file <xml-file> [samples]
-  uppsala-performance-harness suite <roxmltree-benches-dir> [samples]
+  uppsala-performance-harness suite <benchmark-files-dir> [samples]
+  uppsala-performance-harness libxml2-report [samples]
   uppsala-performance-harness saml [samples]"
     );
     std::process::exit(2);
 }
 
 fn main() {
+    let _cleanup = Libxml2Cleanup;
     let args = env::args().collect::<Vec<_>>();
     match args.get(1).map(String::as_str) {
         Some("file") => {
@@ -206,6 +415,7 @@ fn main() {
             let dir = args.get(2).map(PathBuf::from).unwrap_or_else(|| usage());
             run_suite(&dir, parse_samples(&args, 3));
         }
+        Some("libxml2-report") => run_libxml2_report(parse_samples(&args, 2)),
         Some("saml") => run_saml(parse_samples(&args, 2)),
         _ => usage(),
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,12 +451,6 @@ fn is_ascii_name_start(b: u8) -> bool {
     matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'_' | b':')
 }
 
-/// Check if a byte is a valid ASCII XML name character.
-#[inline(always)]
-fn is_ascii_name_char(b: u8) -> bool {
-    matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b':' | b'-' | b'.')
-}
-
 /// Parse an XML Name. Returns a borrowed slice (names never contain entities).
 /// Uses fast ASCII byte scanning with fallback to Unicode for non-ASCII.
 fn parse_name<'a>(cursor: &mut Cursor<'a>) -> XmlResult<Cow<'a, str>> {
@@ -489,22 +483,19 @@ fn parse_name<'a>(cursor: &mut Cursor<'a>) -> XmlResult<Cow<'a, str>> {
         start + c.len_utf8()
     };
 
-    // Scan remaining characters (ASCII fast path)
-    while pos < bytes.len() {
-        let b = bytes[pos];
-        if b < 0x80 {
-            if is_ascii_name_char(b) {
-                pos += 1;
-            } else {
-                break;
-            }
+    // Scan ASCII name continuation bytes in bulk, falling back only when a
+    // non-ASCII byte may start a Unicode NameChar.
+    loop {
+        pos += crate::simd::scan_name_continuation(&bytes[pos..]);
+        if pos >= bytes.len() || bytes[pos] < 0x80 {
+            break;
+        }
+
+        let c = cursor.input[pos..].chars().next().unwrap();
+        if is_name_char(c) {
+            pos += c.len_utf8();
         } else {
-            let c = cursor.input[pos..].chars().next().unwrap();
-            if is_name_char(c) {
-                pos += c.len_utf8();
-            } else {
-                break;
-            }
+            break;
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -472,7 +472,10 @@ fn parse_name<'a>(cursor: &mut Cursor<'a>) -> XmlResult<Cow<'a, str>> {
         }
         start + 1
     } else {
-        let c = cursor.input[start..].chars().next().unwrap();
+        let c = cursor.input[start..]
+            .chars()
+            .next()
+            .ok_or_else(|| XmlError::parse("Expected XML name", cursor.line(), cursor.column()))?;
         if !is_name_start_char(c) {
             return Err(XmlError::parse(
                 "Expected XML name",
@@ -491,7 +494,10 @@ fn parse_name<'a>(cursor: &mut Cursor<'a>) -> XmlResult<Cow<'a, str>> {
             break;
         }
 
-        let c = cursor.input[pos..].chars().next().unwrap();
+        let c = cursor.input[pos..]
+            .chars()
+            .next()
+            .ok_or_else(|| XmlError::parse("Expected XML name", cursor.line(), cursor.column()))?;
         if is_name_char(c) {
             pos += c.len_utf8();
         } else {
@@ -1144,7 +1150,7 @@ fn expand_entity_value(
             }
         } else {
             // Regular character - just advance
-            let c = value[pos..].chars().next().unwrap();
+            let c = value[pos..].chars().next().ok_or(XmlError::UnexpectedEof)?;
             charge_entity_budget(budget, c.len_utf8(), line, col)?;
             result.push(c);
             pos += c.len_utf8();
@@ -1238,7 +1244,7 @@ fn expand_entity_value_no_builtins(
                 pos += 1;
             }
         } else {
-            let c = value[pos..].chars().next().unwrap();
+            let c = value[pos..].chars().next().ok_or(XmlError::UnexpectedEof)?;
             charge_entity_budget(budget, c.len_utf8(), line, col)?;
             result.push(c);
             pos += c.len_utf8();

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -10,6 +10,7 @@
 /// Returns `(bytes_advanced, needs_validation)` where `needs_validation` is true
 /// if any non-ASCII byte (>= 0x80) or illegal control character (< 0x20 except
 /// TAB, LF) was encountered in the scanned range.
+#[inline(always)]
 pub(crate) fn scan_content_delimiters(data: &[u8]) -> (usize, bool) {
     #[cfg(target_arch = "x86_64")]
     {
@@ -26,6 +27,7 @@ pub(crate) fn scan_content_delimiters(data: &[u8]) -> (usize, bool) {
 ///
 /// Returns `(bytes_advanced, needs_validation)` where `needs_validation` is true
 /// if any non-ASCII byte or illegal control character was encountered.
+#[inline(always)]
 pub(crate) fn scan_attr_delimiters(data: &[u8], quote: u8) -> (usize, bool) {
     #[cfg(target_arch = "x86_64")]
     {
@@ -39,9 +41,17 @@ pub(crate) fn scan_attr_delimiters(data: &[u8], quote: u8) -> (usize, bool) {
 }
 
 /// Find a single byte without adding a dependency.
-#[inline]
+#[inline(always)]
 pub(crate) fn find_byte(data: &[u8], byte: u8) -> Option<usize> {
-    data.iter().position(|&b| b == byte)
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is guaranteed on all x86_64 processors.
+        unsafe { find_byte_sse2(data, byte) }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        find_byte_scalar(data, byte)
+    }
 }
 
 /// Length of the prefix of `data` that the serializer's escaper can copy
@@ -50,6 +60,7 @@ pub(crate) fn find_byte(data: &[u8], byte: u8) -> Option<usize> {
 /// start of a multi-byte sequence (>= 0x80, which needs char-level XML
 /// validity checking). The serializer bulk-copies this run and handles the
 /// single following special byte individually.
+#[inline(always)]
 pub(crate) fn scan_escape_run(data: &[u8], is_attr: bool) -> usize {
     #[cfg(target_arch = "x86_64")]
     {
@@ -71,25 +82,45 @@ pub(crate) fn scan_escape_run(data: &[u8], is_attr: bool) -> usize {
 /// "all valid ASCII" (offset == len), an "invalid ASCII name" (offset byte
 /// `< 0x80`), and "fall through to the Unicode `NameChar` production" (offset
 /// byte `>= 0x80`, the start of a multi-byte character).
+#[inline(always)]
 pub(crate) fn scan_ncname_continuation(data: &[u8]) -> usize {
     #[cfg(target_arch = "x86_64")]
     {
         // SAFETY: SSE2 is guaranteed on all x86_64 processors.
-        unsafe { scan_ncname_continuation_sse2(data) }
+        unsafe { scan_name_like_continuation_sse2::<false>(data) }
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        scan_ncname_continuation_scalar(data)
+        scan_name_like_continuation_scalar::<false>(data)
     }
 }
 
-/// Scalar fallback / tail scan for [`scan_ncname_continuation`]. The byte
-/// classification is the reference the SSE2 path must match exactly.
-fn scan_ncname_continuation_scalar(data: &[u8]) -> usize {
+/// Length of the leading run of ASCII XML Name continuation characters
+/// (`[0-9A-Za-z_.:-]`). Non-ASCII bytes stop the run so the parser can fall
+/// through to the full Unicode `NameChar` production.
+#[inline(always)]
+pub(crate) fn scan_name_continuation(data: &[u8]) -> usize {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: SSE2 is guaranteed on all x86_64 processors.
+        unsafe { scan_name_like_continuation_sse2::<true>(data) }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        scan_name_like_continuation_scalar::<true>(data)
+    }
+}
+
+/// Scalar fallback / tail scan for XML name-like continuation scanners. The
+/// byte classification is the reference the SSE2 path must match exactly.
+fn scan_name_like_continuation_scalar<const ALLOW_COLON: bool>(data: &[u8]) -> usize {
     let mut pos = 0;
     while pos < data.len() {
         let b = data[pos];
-        if !(b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.')) {
+        if !(b.is_ascii_alphanumeric()
+            || matches!(b, b'_' | b'-' | b'.')
+            || (ALLOW_COLON && b == b':'))
+        {
             break;
         }
         pos += 1;
@@ -99,11 +130,11 @@ fn scan_ncname_continuation_scalar(data: &[u8]) -> usize {
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse2")]
-unsafe fn scan_ncname_continuation_sse2(data: &[u8]) -> usize {
+unsafe fn scan_name_like_continuation_sse2<const ALLOW_COLON: bool>(data: &[u8]) -> usize {
     use std::arch::x86_64::*;
 
     let mut pos = 0;
-    // Range bounds and the three standalone characters `_ - .`.
+    // Range bounds and standalone XML-name punctuation.
     let v_0 = _mm_set1_epi8(b'0' as i8);
     let v_9 = _mm_set1_epi8(b'9' as i8);
     let v_ua = _mm_set1_epi8(b'A' as i8);
@@ -113,6 +144,7 @@ unsafe fn scan_ncname_continuation_sse2(data: &[u8]) -> usize {
     let v_us = _mm_set1_epi8(b'_' as i8);
     let v_hy = _mm_set1_epi8(b'-' as i8);
     let v_dot = _mm_set1_epi8(b'.' as i8);
+    let v_colon = _mm_set1_epi8(b':' as i8);
 
     while pos + 16 <= data.len() {
         let chunk = _mm_loadu_si128(data.as_ptr().add(pos) as *const __m128i);
@@ -130,6 +162,11 @@ unsafe fn scan_ncname_continuation_sse2(data: &[u8]) -> usize {
             _mm_cmpeq_epi8(chunk, v_us),
             _mm_or_si128(_mm_cmpeq_epi8(chunk, v_hy), _mm_cmpeq_epi8(chunk, v_dot)),
         );
+        let singles = if ALLOW_COLON {
+            _mm_or_si128(singles, _mm_cmpeq_epi8(chunk, v_colon))
+        } else {
+            singles
+        };
         let valid = _mm_or_si128(
             _mm_or_si128(in_range(v_0, v_9), in_range(v_ua, v_uz)),
             _mm_or_si128(in_range(v_la, v_lz), singles),
@@ -144,7 +181,29 @@ unsafe fn scan_ncname_continuation_sse2(data: &[u8]) -> usize {
         pos += 16;
     }
 
-    pos + scan_ncname_continuation_scalar(&data[pos..])
+    pos + scan_name_like_continuation_scalar::<ALLOW_COLON>(&data[pos..])
+}
+
+fn find_byte_scalar(data: &[u8], byte: u8) -> Option<usize> {
+    data.iter().position(|&b| b == byte)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse2")]
+unsafe fn find_byte_sse2(data: &[u8], byte: u8) -> Option<usize> {
+    use std::arch::x86_64::*;
+
+    let mut pos = 0;
+    let needle = _mm_set1_epi8(byte as i8);
+    while pos + 16 <= data.len() {
+        let chunk = _mm_loadu_si128(data.as_ptr().add(pos) as *const __m128i);
+        let mask = _mm_movemask_epi8(_mm_cmpeq_epi8(chunk, needle)) as u32;
+        if mask != 0 {
+            return Some(pos + mask.trailing_zeros() as usize);
+        }
+        pos += 16;
+    }
+    find_byte_scalar(&data[pos..], byte).map(|tail| pos + tail)
 }
 
 /// Scalar fallback / tail scan for [`scan_escape_run`]. The byte
@@ -579,6 +638,17 @@ mod tests {
     }
 
     #[test]
+    fn name_continuation_allows_colon() {
+        // Parser XML Names allow ':'; serializer NCNames intentionally do not.
+        assert_eq!(scan_name_continuation(b"abc:def-1.2_z"), 13);
+        assert_eq!(scan_ncname_continuation(b"abc:def-1.2_z"), 3);
+        assert_eq!(scan_name_continuation(b"abc def"), 3);
+        assert_eq!(scan_name_continuation("abc\u{e9}".as_bytes()), 3);
+        assert_eq!(scan_name_continuation(b"aaaaaaaaaaaaaaaaaa"), 18);
+        assert_eq!(scan_name_continuation(b"aaaaaaaaaaaaaaaaa/"), 17);
+    }
+
+    #[test]
     fn ncname_continuation_sse2_matches_scalar() {
         // Differential spot-check (the exhaustive check lives in the fuzz
         // harness fuzz_simd_differential): every stop byte at every position
@@ -590,10 +660,44 @@ mod tests {
                     d[p] = sp;
                     assert_eq!(
                         scan_ncname_continuation(&d),
-                        scan_ncname_continuation_scalar(&d),
+                        scan_name_like_continuation_scalar::<false>(&d),
                         "len={len} pos={p} byte={sp:#04x}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn name_continuation_sse2_matches_scalar() {
+        for len in 0..40usize {
+            for p in 0..len {
+                for &sp in &[b' ', b'/', 0x00u8, 0x80u8, 0xFFu8] {
+                    let mut d = vec![b'a'; len];
+                    d[p] = sp;
+                    assert_eq!(
+                        scan_name_continuation(&d),
+                        scan_name_like_continuation_scalar::<true>(&d),
+                        "len={len} pos={p} byte={sp:#04x}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn find_byte_matches_scalar() {
+        for len in 0..40usize {
+            for p in 0..=len {
+                let mut d = vec![b'a'; len];
+                if p < len {
+                    d[p] = b';';
+                }
+                assert_eq!(
+                    find_byte(&d, b';'),
+                    find_byte_scalar(&d, b';'),
+                    "len={len} pos={p}"
+                );
             }
         }
     }
@@ -643,6 +747,12 @@ pub mod fuzz_exports {
     pub fn scan_ncname_continuation(data: &[u8]) -> usize {
         super::scan_ncname_continuation(data)
     }
+    pub fn scan_name_continuation(data: &[u8]) -> usize {
+        super::scan_name_continuation(data)
+    }
+    pub fn find_byte(data: &[u8], byte: u8) -> Option<usize> {
+        super::find_byte(data, byte)
+    }
 
     /// Scalar references — the ground truth, available on every architecture.
     pub fn scan_content_scalar(data: &[u8]) -> (usize, bool) {
@@ -655,7 +765,13 @@ pub mod fuzz_exports {
         super::scan_escape_scalar(data, is_attr)
     }
     pub fn scan_ncname_continuation_scalar(data: &[u8]) -> usize {
-        super::scan_ncname_continuation_scalar(data)
+        super::scan_name_like_continuation_scalar::<false>(data)
+    }
+    pub fn scan_name_continuation_scalar(data: &[u8]) -> usize {
+        super::scan_name_like_continuation_scalar::<true>(data)
+    }
+    pub fn find_byte_scalar(data: &[u8], byte: u8) -> Option<usize> {
+        super::find_byte_scalar(data, byte)
     }
 
     /// SSE2 implementations (x86_64 only). Safe wrappers: SSE2 is guaranteed on
@@ -674,7 +790,15 @@ pub mod fuzz_exports {
     }
     #[cfg(target_arch = "x86_64")]
     pub fn scan_ncname_continuation_sse2(data: &[u8]) -> usize {
-        unsafe { super::scan_ncname_continuation_sse2(data) }
+        unsafe { super::scan_name_like_continuation_sse2::<false>(data) }
+    }
+    #[cfg(target_arch = "x86_64")]
+    pub fn scan_name_continuation_sse2(data: &[u8]) -> usize {
+        unsafe { super::scan_name_like_continuation_sse2::<true>(data) }
+    }
+    #[cfg(target_arch = "x86_64")]
+    pub fn find_byte_sse2(data: &[u8], byte: u8) -> Option<usize> {
+        unsafe { super::find_byte_sse2(data, byte) }
     }
 
     /// Escape `s` through the real serializer escaper (`write_escaped_run_dyn`),


### PR DESCRIPTION
Add x86_64-oriented parser fast paths for byte/name scanning, including inline SIMD helpers and an ASCII name-continuation scanner used by parse_name. Reduce byte-at-a-time parsing in hot paths while preserving fallback handling for non-ASCII names.

Replace the roxmltree comparison harness with a libxml2-backed benchmark path, including static libxml2 linking, larger generated XML fixtures, and real-world-style benchmark cases. Add a `bench-libxml2` just target that builds libxml2 from `../libxml2` by default, supports `LIBXML2_DIR` and `LIBXML2_LIB_DIR` overrides, builds the harness with native CPU flags, and prints the final comparison table.

Update performance documentation and harness README with the new libxml2 workflow, build notes, benchmark fixtures, and current comparison results